### PR TITLE
seo: 8 nya sidor, sitemap 18 URLs, uppdaterade footers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,105 @@
+# Efterplan.se — Trafiköversikt & Roadmap
+
+Senast uppdaterad: april 2026
+
+---
+
+## SEO-sidor
+
+| Sida | Primärt sökord | Est. sök/mån | Status |
+|------|---------------|-------------|--------|
+| index.html | efterplan / dödsbo app | — | ✅ Live |
+| vad-gora-nar-nagon-dor.html | vad gör man när någon dör | 3 000 | ✅ Live |
+| checklista-dodsbo.html | checklista dödsbo | 2 500 | ✅ Live |
+| bouppteckning-guide.html | bouppteckning | 8 000 | ✅ Live |
+| vad-kostar-en-begravning.html | vad kostar en begravning | 3 500 | ✅ Live |
+| arvskifte-guide.html | arvskifte | 4 000 | ✅ Live |
+| efterlevandepension.html | efterlevandepension | 2 500 | ✅ Live |
+| testamente-guide.html | skriva testamente | 4 000 | ✅ Live |
+| dodsbo-bostadsratt.html | dödsbo bostadsrätt | 1 500 | ✅ Live |
+| arvsskatt.html | arvsskatt Sverige | 3 000 | ✅ Live |
+| sambo-arv.html | sambo arv | 4 000 | ✅ Byggt |
+| tomma-dodsbo.html | tömma dödsbo | 6 000 | ✅ Byggt |
+| sarkullbarn.html | särkullbarn | 2 500 | ✅ Byggt |
+| salja-dodsbo.html | sälja dödsbo | 3 500 | ✅ Byggt |
+| dodsbo-skulder.html | dödsbo skulder | 2 000 | ✅ Byggt |
+| dodsbo-deklaration.html | deklarera dödsbo | 2 000 | ✅ Byggt |
+| fullmakt-dodsbo.html | fullmakt dödsfall | 1 500 | ✅ Byggt |
+| bankkonto-dodsfall.html | bankkonto dödsfall | 2 500 | ✅ Byggt |
+
+**Estimerad total organisk räckvidd när alla 18 sidor är indexerade: ~50 000 sök/mån**
+
+---
+
+## Teknisk SEO
+
+| Uppgift | Status |
+|---------|--------|
+| Sitemap.xml (18 URLs) | ✅ Klar |
+| robots.txt | ✅ Klar |
+| Canonical tags på alla sidor | ✅ Klar |
+| Article + FAQPage schema på alla sidor | ✅ Klar |
+| OG-taggar (title, description, image) | ✅ Klar |
+| GA4-spårning på alla sidor | ✅ Klar |
+| _redirects (statiska filer före catch-all) | ✅ Klar |
+| Google Search Console — verifiera + skicka sitemap | ⬜ Manuell uppgift |
+| Core Web Vitals — mät och optimera | ⬜ Backlogg |
+| BreadcrumbList schema | ⬜ Backlogg |
+
+---
+
+## Länkbygge (manuella uppgifter)
+
+| Källa | Potential | Status |
+|-------|-----------|--------|
+| 1177.se länkbegäran | ⭐⭐⭐⭐⭐ | ⬜ Ej gjort |
+| Mediepitch Aftonbladet/DN/SVT | ⭐⭐⭐⭐⭐ | ⬜ Ej gjort |
+| Försäkringsbolag (Folksam, Läns, Trygg-Hansa, Skandia) | ⭐⭐⭐⭐ | ⬜ Ej gjort |
+| Banker (Swedbank, SEB, Handelsbanken, Nordea) | ⭐⭐⭐⭐ | ⬜ Ej gjort |
+| Sorgorganisationer (SPES, Sorg.se, Svenska kyrkan) | ⭐⭐⭐ | ⬜ Ej gjort |
+| Begravningsbyråer (10-20 lokala) | ⭐⭐⭐ | ⬜ Ej gjort |
+| Reddit r/sweden + r/privatekonomi | ⭐⭐ | ⬜ Ej gjort |
+| Facebook-grupper (dödsbo-relaterade) | ⭐⭐ | ⬜ Ej gjort |
+| Kommuners socialtjänst-sidor (12 kommuner kontaktade) | ⭐⭐⭐ | ✅ Mejl skickat |
+
+---
+
+## Produkt / UX-backlogg
+
+| Uppgift | Status |
+|---------|--------|
+| Auto-scroll till nästa uppgift | ✅ Klar |
+| Förtroendeband (Kostnadsfritt · Ingen registrering · ...) | ✅ Klar |
+| Nöjd-kund-garanti badge | ⬜ Väntar på Stripe |
+| Google Customer Reviews-stämpel | ⬜ Väntar på Stripe |
+| Paywall + Stripe-integration | ⬜ Backlogg |
+| GA4 KPI-dashboard | ✅ Byggt |
+
+---
+
+## Prioriteringsmatris
+
+| Åtgärd | Tid | SEO-effekt | Svårighet | Prioritet |
+|--------|-----|-----------|----------|----------|
+| Google Search Console setup | 30 min | Kritisk | Lätt | 🔴 Nu |
+| 1177.se länkbegäran | 1 h | ⭐⭐⭐⭐⭐ | Medium | 🔴 Nu |
+| Mediepitch | 2 h | ⭐⭐⭐⭐⭐ | Medium | 🔴 Nu |
+| Merga alla nya sidor → main | 5 min | Kritisk | Lätt | 🔴 Nu |
+| Försäkringsbolag | 3 h | ⭐⭐⭐⭐ | Lätt | 🟠 Snart |
+| Banker | 3 h | ⭐⭐⭐⭐ | Lätt | 🟠 Snart |
+| Reddit/sociala medier | 1 h | ⭐⭐ | Lätt | 🟡 Löpande |
+| Begravningsbyråer | 4 h | ⭐⭐⭐ | Lätt | 🟡 Löpande |
+
+---
+
+## Kommande SEO-sidor (nästa batch)
+
+Potentiella sidor att bygga om trafikdata bekräftar efterfrågan:
+
+| Sida | Sökord | Est. sök/mån |
+|------|--------|-------------|
+| gravsten.html | gravsten kostnad | 1 500 |
+| dodsbo-auktion.html | dödsbo auktion | 1 200 |
+| begravning-utomlands.html | begravning utlandet | 800 |
+| digital-dodsbo.html | digitalt dödsbo | 1 000 |
+| dodsbo-bil.html | dödsbo bil | 1 000 |

--- a/arvskifte-guide.html
+++ b/arvskifte-guide.html
@@ -154,14 +154,14 @@
   <footer class="seo-footer">
     <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
     <p class="seo-footer-links">
-      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
-      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
       <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
-      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
-      <a href="./dodsbo-bostadsratt.html">Dödsbo bostadsrätt</a> &nbsp;·&nbsp;
+      <a href="./salja-dodsbo.html">Sälja dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./sarkullbarn.html">Särkullbarn</a> &nbsp;·&nbsp;
+      <a href="./sambo-arv.html">Sambo och arv</a> &nbsp;·&nbsp;
       <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
-      <a href="./efterlevandepension.html">Efterlevandepension</a> &nbsp;·&nbsp;
-      <a href="./vad-kostar-en-begravning.html">Vad kostar en begravning?</a>
+      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
     </p>
   </footer>
 </body>

--- a/arvsskatt.html
+++ b/arvsskatt.html
@@ -151,14 +151,14 @@
   <footer class="seo-footer">
     <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
     <p class="seo-footer-links">
-      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-deklaration.html">Deklarera dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./salja-dodsbo.html">Sälja dödsbo</a> &nbsp;·&nbsp;
       <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
       <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
-      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
       <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
-      <a href="./dodsbo-bostadsratt.html">Dödsbo bostadsrätt</a> &nbsp;·&nbsp;
-      <a href="./efterlevandepension.html">Efterlevandepension</a> &nbsp;·&nbsp;
-      <a href="./vad-kostar-en-begravning.html">Vad kostar en begravning?</a>
+      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
     </p>
   </footer>
 </body>

--- a/bankkonto-dodsfall.html
+++ b/bankkonto-dodsfall.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bankkonto vid dödsfall — vad händer med kontot när någon dör? | Efterplan</title>
+  <meta name="description" content="Vad händer med bankkontot när en person dör? Banken fryser kontot, men dödsboet kan betala löpande kostnader. Guide 2026 om bankkonto, lån och bankärenden vid dödsfall.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/bankkonto-dodsfall.html">
+  <meta property="og:title" content="Bankkonto vid dödsfall — vad händer med kontot?">
+  <meta property="og:description" content="Banken fryser den dödes konton vid dödsfall. Lär dig vad dödsboet får göra, när pengar frigörs och hur du hanterar lån och gemensamma konton.">
+  <meta property="og:url" content="https://efterplan.se/bankkonto-dodsfall.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Bankkonto vid dödsfall — vad händer med kontot när någon dör?",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-15",
+    "dateModified": "2026-04-15",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/bankkonto-dodsfall.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Fryser banken kontot direkt när någon dör?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja, i princip. Banken ska blockera kontot när de informeras om dödsfallet för att skydda dödsboets tillgångar. Automatiska betalningar (autogiro) kan fortsätta tills banken fått besked om dödsfallet. Informera banken snarast möjligt." }
+      },
+      {
+        "@type": "Question",
+        "name": "Kan dödsboet ta ut pengar från kontot direkt?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Dödsboet kan använda medel på kontot för begravningskostnader och nödvändiga löpande kostnader (hyra, el) direkt — utan att invänta bouppteckning. För att ta ut övriga medel eller fördela arv krävs att bouppteckning är registrerad och arvskiftet genomfört." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad händer med gemensamma bankkonton?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Om kontot är gemensamt (båda makarna är kontohavare) kan den efterlevande maken normalt fortsätta använda sin hälft av kontot. Den dödes hälft ingår i dödsboet. Kontakta banken för att klargöra kontots ställning." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad händer med den dödes lån?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Lån ingår i dödsboets skulder och ska betalas av dödsboets tillgångar. Om kontot är gemensamt (bolån med båda makarna) kvarstår den efterlevande makens betalningsskyldighet för hela lånet. Kontakta banken omgående för att gå igenom alla kreditengagemang." }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Bankkonto vid dödsfall — vad händer?</h1>
+
+      <p>Ett av de första praktiska stegen efter ett dödsfall är att kontakta banken. Vad händer med den dödes konton? Kan du ta ut pengar för begravningen? Vad händer med gemensamma konton och bolån? Den här guiden svarar på de vanligaste frågorna om bankärenden vid dödsfall.</p>
+
+      <h2>Kontakta banken snarast</h2>
+      <p>Informera banken om dödsfallet så snart som möjligt — helst inom ett par dagar. Banken behöver:</p>
+      <ul>
+        <li>Dödsfallsintyg (utfärdat av Skatteverket, kan beställas kostnadsfritt)</li>
+        <li>Kontaktuppgifter till den person som sköter dödsboet</li>
+      </ul>
+      <p>Banken registrerar då dödsfallet och blockerar de befintliga kontona för att skydda dödsboets tillgångar. Autogirobetalningar stoppas. Eventuella bankfullmakter upphör automatiskt vid dödsfallet.</p>
+
+      <h2>Vad händer med kontona?</h2>
+      <p>Kontona övergår till dödsboets förvaltning. Det innebär:</p>
+      <ul>
+        <li>Kontona är blockerade för normala uttag tills dödsboet är utrett.</li>
+        <li>Dödsboet kan använda medlen för nödvändiga kostnader — begravning, hyra, el — direkt.</li>
+        <li>För övriga uttag och för att avsluta kontona krävs bouppteckning.</li>
+        <li>Pengar på kontona ingår i bouppteckningen och redovisas som tillgångar i dödsboet.</li>
+      </ul>
+
+      <h2>Vad kan dödsboet betala direkt?</h2>
+      <p>Trots att kontona är blockerade har dödsboet rätt att använda medlen för:</p>
+      <ul>
+        <li><strong>Begravningskostnader</strong> — inklusive begravningsbyrå, kistpeng, begravningsceremoni och minnesstund.</li>
+        <li><strong>Löpande hyra och boendekostnader</strong> — dödsboet är ansvarigt för hyran tills avtalet är uppsagt.</li>
+        <li><strong>El, vatten och internet</strong> — fram tills avtal är avslutade.</li>
+        <li><strong>Försäkringspremier</strong> — för att hålla egendom (fastighet, fordon) försäkrad under utredningstiden.</li>
+      </ul>
+      <p>Kontakta banken och berätta vad betalningen gäller — de hjälper normalt till att genomföra nödvändiga utbetalningar.</p>
+
+      <h2>Gemensamma konton</h2>
+      <p>Om kontot är ett <strong>gemensamt konto</strong> (båda makarna/samborna är registrerade kontohavare) är situationen annorlunda:</p>
+      <ul>
+        <li>Den efterlevande maken/sambons kan normalt fortsätta använda sin del av kontot — den del som är deras.</li>
+        <li>Den dödes del av kontot ingår i dödsboet.</li>
+        <li>I praktiken brukar banken tillåta löpande betalningar från gemensamma konton medan bouppteckning pågår, men reglerna varierar mellan banker.</li>
+        <li>Kontakta banken för att klargöra vad som gäller för just era konton.</li>
+      </ul>
+
+      <h2>Vad händer med lån och krediter?</h2>
+      <p>Lån som den döde hade ingår i dödsboets skulder och hanteras på olika sätt beroende på lånetyp:</p>
+
+      <h3>Bolån — gemensamt</h3>
+      <p>Om bolånet är tecknat gemensamt (båda makarna som låntagare) kvarstår den <strong>efterlevande makens</strong> fulla betalningsansvar för hela lånet. Den dödes del av lånet ingår i dödsboet som en skuld. Banken bör kontaktas för att eventuellt lägga om lånet på enbart den efterlevande makens namn.</p>
+
+      <h3>Bolån — enskilt</h3>
+      <p>Om bolånet enbart stod på den döde ingår skulden i dödsboet. Dödsboet ansvarar för att betala ränta och amorteringar tills fastigheten är såld eller överlåten till arvingarna.</p>
+
+      <h3>Konsumtionslån och kreditkort</h3>
+      <p>Skulder på kreditkort och konsumtionslån ingår i dödsboet. Om den döde hade en medsökande (t.ex. make/sambo) kan den personen ha ett gemensamt ansvar — kontakta kreditgivaren för att klargöra.</p>
+
+      <h3>Autogiro och direktbetalningar</h3>
+      <p>Avbryt autogirobetalningar som inte är nödvändiga. Prenumerationer, streamingstjänster, telefonabonnemang och liknande bör avregistreras snarast för att undvika onödiga kostnader för dödsboet.</p>
+
+      <h2>Bankens besked — vad du behöver för att avsluta konton</h2>
+      <p>För att avsluta konton och ta ut alla tillgångar ur dödsboet kräver banken normalt:</p>
+      <ol>
+        <li><strong>Registrerad bouppteckning</strong> — det vill säga den bouppteckning som Skatteverket stämplat. Banken behöver se den för att identifiera dödsbodelägarna.</li>
+        <li><strong>Arvskifteshandling eller fullmakt</strong> — om pengarna ska fördelas till arvingarna kräver banken en arvskifteshandling eller fullmakt undertecknad av samtliga dödsbodelägare.</li>
+        <li><strong>ID-handlingar</strong> — för den som genomför utbetalningen.</li>
+      </ol>
+
+      <h2>Värdepapper och fonder</h2>
+      <p>Om den döde hade aktier, fonder eller ett ISK hanteras dessa separat:</p>
+      <ul>
+        <li><strong>ISK (Investeringssparkonto)</strong> — avslutas vid dödsfall och värdepappren förs över till ett vanligt depåkonto i dödsboets namn.</li>
+        <li><strong>Vanligt aktiedepå</strong> — övergår till dödsboet. Värdepappren kan säljas eller skiftas i befintlig form till arvingarna.</li>
+        <li><strong>Kapitalförsäkring</strong> — om det finns en utsedd förmånstagare betalas försäkringen ut direkt till förmånstagaren, utanför dödsboet.</li>
+      </ul>
+
+      <h2>Digitala konton och abonnemang</h2>
+      <p>Glöm inte att informera och avsluta digitala tjänster:</p>
+      <ul>
+        <li>Swish — registrerat på personnummer, avslutas automatiskt vid dödsfall men meddela banken.</li>
+        <li>Bankernas internetbank och app — avaktiveras när banken informerats.</li>
+        <li>PayPal och övriga betaltjänster — kontakta respektive tjänst med dödsatttest.</li>
+        <li>Prenumerationer (Spotify, Netflix, tidningar) — säg upp via respektive tjänst.</li>
+      </ul>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Hur snabbt fryser banken kontot?</h3>
+      <p>Det varierar. De flesta banker blockerar kontot inom några dagar efter att de informerats. Om du inte informerar banken kan kontot fortsätta vara öppet — men det är din skyldighet som dödsbodelägare att se till att dödsboets tillgångar är skyddade.</p>
+
+      <h3>Kan vi öppna ett nytt bankkonto för dödsboet?</h3>
+      <p>Ja. Det är möjligt att öppna ett dödsboänto för att samla dödsboets inbetalningar (försäkringsutbetalningar, hyresintäkter m.m.) och göra utbetalningar. Kontakta banken och berätta att det gäller ett dödsbo — du behöver bouppteckning och fullmakt från dödsbodelägarna.</p>
+
+      <h3>Vad händer med den dödes Swish?</h3>
+      <p>Swish är kopplat till den dödes telefonnummer och personnummer. Banken avslutar Swish-kontot när de informeras om dödsfallet. Medel som eventuellt finns kvar på Swish-kontot ingår i dödsboet.</p>
+
+      <div class="seo-cta">
+        <p>Hantera alla praktiska steg efter ett dödsfall — komplett checklista för dödsboet</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./fullmakt-dodsbo.html">Fullmakt dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-deklaration.html">Deklarera dödsbo</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
+      <a href="./tomma-dodsbo.html">Tömma dödsbo</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/bouppteckning-guide.html
+++ b/bouppteckning-guide.html
@@ -163,13 +163,13 @@
     <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
     <p class="seo-footer-links">
       <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
-      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-deklaration.html">Deklarera dödsbo</a> &nbsp;·&nbsp;
+      <a href="./fullmakt-dodsbo.html">Fullmakt dödsbo</a> &nbsp;·&nbsp;
       <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
-      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
-      <a href="./dodsbo-bostadsratt.html">Dödsbo bostadsrätt</a> &nbsp;·&nbsp;
       <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
-      <a href="./efterlevandepension.html">Efterlevandepension</a> &nbsp;·&nbsp;
-      <a href="./vad-kostar-en-begravning.html">Vad kostar en begravning?</a>
+      <a href="./bankkonto-dodsfall.html">Bankkonto vid dödsfall</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
     </p>
   </footer>
 </body>

--- a/checklista-dodsbo.html
+++ b/checklista-dodsbo.html
@@ -161,12 +161,12 @@
     <p class="seo-footer-links">
       <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
       <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./tomma-dodsbo.html">Tömma dödsbo</a> &nbsp;·&nbsp;
+      <a href="./salja-dodsbo.html">Sälja dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./bankkonto-dodsfall.html">Bankkonto vid dödsfall</a> &nbsp;·&nbsp;
       <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
-      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
-      <a href="./dodsbo-bostadsratt.html">Dödsbo bostadsrätt</a> &nbsp;·&nbsp;
-      <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
-      <a href="./efterlevandepension.html">Efterlevandepension</a> &nbsp;·&nbsp;
-      <a href="./vad-kostar-en-begravning.html">Vad kostar en begravning?</a>
+      <a href="./fullmakt-dodsbo.html">Fullmakt dödsbo</a>
     </p>
   </footer>
 </body>

--- a/dodsbo-bostadsratt.html
+++ b/dodsbo-bostadsratt.html
@@ -139,14 +139,14 @@
   <footer class="seo-footer">
     <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
     <p class="seo-footer-links">
-      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
-      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
+      <a href="./salja-dodsbo.html">Sälja dödsbo</a> &nbsp;·&nbsp;
+      <a href="./tomma-dodsbo.html">Tömma dödsbo</a> &nbsp;·&nbsp;
       <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
       <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
-      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
       <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
-      <a href="./efterlevandepension.html">Efterlevandepension</a> &nbsp;·&nbsp;
-      <a href="./vad-kostar-en-begravning.html">Vad kostar en begravning?</a>
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
     </p>
   </footer>
 </body>

--- a/dodsbo-deklaration.html
+++ b/dodsbo-deklaration.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deklarera dödsbo — inkomstdeklaration för dödsbo 2026 | Efterplan</title>
+  <meta name="description" content="Dödsboet måste deklarera för dödsåret och eventuellt efterföljande år. Lär dig hur dödsboets inkomstdeklaration fungerar, vad som ska tas upp och viktiga datum.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/dodsbo-deklaration.html">
+  <meta property="og:title" content="Deklarera dödsbo — inkomstdeklaration för dödsbo 2026">
+  <meta property="og:description" content="Dödsboet är ett eget skattesubjekt. Lär dig vad som ska deklareras, när och hur — komplett guide för dödsboets inkomstdeklaration.">
+  <meta property="og:url" content="https://efterplan.se/dodsbo-deklaration.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Deklarera dödsbo — inkomstdeklaration för dödsbo 2026",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-15",
+    "dateModified": "2026-04-15",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/dodsbo-deklaration.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Måste dödsboet deklarera?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja. Dödsboet är ett eget skattesubjekt från dödsdagen och måste lämna en inkomstdeklaration för det år personen dog. Om dödsboet inte är avslutat vid årets slut ska det också deklarera för efterföljande år." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vem lämnar in dödsboets deklaration?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Dödsbodelägarna ansvarar gemensamt för att deklarationen lämnas in. I praktiken är det vanligt att en av delägarna eller en anlitad redovisningskonsult sköter det. Dödsboet ska använda personnumret för den döde som skatteidentitetsnummer." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad ska dödsboet deklarera?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Dödsboet ska deklarera alla inkomster som uppstått efter dödsdagen: ränta, utdelning, hyresintäkter och kapitalvinster vid försäljning av tillgångar. Inkomster innan dödsfallet ingår i den dödes sista deklaration (slutdeklaration)." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad är skillnaden mellan dödsboets deklaration och den dödes sista deklaration?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Den dödes sista deklaration täcker inkomster från 1 januari till dödsdagen — lön, pension, ränta m.m. Dödsboets deklaration täcker inkomster från dödsdagen framåt — avkastning på tillgångar dödsboet förvaltade, hyresintäkter och kapitalvinster vid försäljning." }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Deklarera dödsbo — så fungerar inkomstdeklarationen</h1>
+
+      <p>Dödsboet är inte bara en juridisk konstruktion för att fördela arv — det är också ett <strong>eget skattesubjekt</strong>. Det innebär att dödsboet har egna skattskyldigheter och måste lämna en inkomstdeklaration, precis som en privatperson eller ett företag. Den här guiden förklarar vad det innebär i praktiken, vad som ska deklareras och hur processen fungerar.</p>
+
+      <h2>Två deklarationer vid ett dödsfall</h2>
+      <p>När en person dör uppstår det <em>två separata</em> deklarationsskyldigheter:</p>
+
+      <h3>1. Den dödes sista deklaration (slutdeklaration)</h3>
+      <p>Detta är en vanlig inkomstdeklaration som täcker perioden <strong>1 januari till dödsdagen</strong>. Den inkluderar:</p>
+      <ul>
+        <li>Lön och pension fram till dödsfallet</li>
+        <li>Ränta och utdelning fram till dödsfallet</li>
+        <li>Kapitalvinster på försäljningar gjorda innan dödsfallet</li>
+      </ul>
+      <p>Skatteverket skickar normalt ut en förtryckt blankett (INK1) automatiskt. Dödsbodelägarna undertecknar och lämnar in den. Deadline är normalt 2 maj nästkommande år (kan begäras förlängt).</p>
+
+      <h3>2. Dödsboets deklaration</h3>
+      <p>Dödsboet börjar existera som skattesubjekt från och med <strong>dödsdagen</strong>. Från den dagen gäller att alla inkomster som uppstår i dödsboet är dödsboets inkomster — inte den dödes och inte arvingars.</p>
+      <p>Dödsboets deklaration täcker inkomster från dödsdagen till och med 31 december samma år. Finns dödsboet kvar efter årets slut ska det också lämna in deklarationer för varje efterföljande år tills det är avslutat.</p>
+
+      <h2>Vad ska dödsboet deklarera?</h2>
+      <p>Dödsboet deklarerar inkomster av kapital och eventuellt inkomst av näringverksamhet om den döde drev ett företag:</p>
+
+      <h3>Inkomst av kapital</h3>
+      <ul>
+        <li><strong>Ränta:</strong> Ränta på bankkonton som uppstår efter dödsdagen.</li>
+        <li><strong>Utdelning:</strong> Aktieutdelningar som betalas ut efter dödsdagen.</li>
+        <li><strong>Hyresintäkter:</strong> Om dödsboet äger en fastighet som hyrs ut.</li>
+        <li><strong>Kapitalvinster:</strong> Vid försäljning av fastigheter, bostadsrätter, aktier, fonder och andra tillgångar under dödsboets livstid.</li>
+      </ul>
+
+      <h3>Inkomst av näringverksamhet</h3>
+      <p>Om den döde drev ett enskilt företag eller var delägare i ett handelsbolag fortsätter verksamheten som dödsboets under avvecklingstiden. Rörelsens intäkter och kostnader deklareras av dödsboet tills verksamheten är avvecklad eller överlåten.</p>
+
+      <h2>Skattesatser för dödsboet</h2>
+      <p>Dödsboet beskattas inte som en privatperson — det finns inga grundavdrag eller jobbskatteavdrag. Skattesatserna är:</p>
+      <ul>
+        <li><strong>Kapitalinkomster:</strong> 30 % (ränta, utdelning, kapitalvinster på aktier/fonder)</li>
+        <li><strong>Kapitalvinst fastighet:</strong> 22 % (schablonregeln 30 % × 22/30)</li>
+        <li><strong>Kapitalvinst bostadsrätt:</strong> 22 %</li>
+        <li><strong>Näringsinkomster:</strong> 20 % (proportionell statlig inkomstskatt)</li>
+      </ul>
+      <p>Dödsboet beskattas alltså med en <em>proportionell</em> skattesats — det finns inga progressiva skiktgränser som för levande personer. Det innebär att ett dödsbo som säljer en fastighet med stor vinst inte drabbas av extra hög marginalskatt.</p>
+
+      <h2>Hur lämnas deklarationen in?</h2>
+      <ol>
+        <li><strong>Skatteverket skickar blankett automatiskt.</strong> Dödsboet tilldelas automatiskt ett deklarationsunderlag. Det skickas till den folkbokföringsadress den döde hade — eller till den adress som dödsboets kontaktperson anmält.</li>
+        <li><strong>Kontrolluppgifter sammanställs.</strong> Banker, fondbolag och bolag skickar kontrolluppgifter till Skatteverket med ränta, utdelning och köp/sälj av värdepapper.</li>
+        <li><strong>Fyll i och signera.</strong> Deklarationen fylls i och undertecknas av dödsbodelägarna (eller en fullmäktig).</li>
+        <li><strong>Lämna in senast 2 maj.</strong> Deklarationen ska lämnas senast 2 maj året efter inkomståret. Dödsbon kan begära anstånd precis som vanliga skattebetalare.</li>
+      </ol>
+
+      <h2>Dödsbo och ISK (Investeringssparkonto)</h2>
+      <p>ISK är ett vanligt sparande i Sverige och hanteras speciellt vid dödsfall. Ett ISK kan inte ägas av ett dödsbo — kontot avslutas vid dödsfall och värdepappren på kontot förs över till ett vanligt värdepapperskonto i dödsboets namn. Schablonskatten (ISK-skatten) beräknas fram till dödsdagen och ingår i den dödes sista deklaration.</p>
+      <p>Värdepappren på det vanliga värdepapperskontot (efter övergången) beskattas normalt — kapitalvinst vid försäljning beskattas med 30 %.</p>
+
+      <h2>Dödsbo och pension</h2>
+      <p>Privat pensionsförsäkring och tjänstepension utbetalas normalt till förmånstagare utanför dödsboet. Dessa utbetalningar är inkomst av tjänst för förmånstagaren — de ska deklareras av förmånstagaren, inte av dödsboet.</p>
+      <p>Allmän pension (från Pensionsmyndigheten) stoppas vid dödsfallet. Eventuell retroaktiv utbetalning för den månad personen dog ingår i dödsboet och dödsboets deklaration.</p>
+
+      <h2>Avsluta dödsboet</h2>
+      <p>Dödsboet upphör att vara skattesubjekt när arvskiftet är genomfört och all egendom har fördelats till arvingarna. Skatteverket avslutar då dödsboets skatteregistrering. Om dödsboet äger fastigheter eller bedriver verksamhet kan det ta lång tid — ett dödsbo kan existera i år om arvingarna inte kommer överens.</p>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Kan jag deklarera dödsboet digitalt via Skatteverkets e-tjänst?</h3>
+      <p>Ja, i de flesta fall. Dödsbodelägare med e-legitimation kan logga in på Skatteverkets e-tjänst och hantera dödsboets deklaration digitalt. Du behöver personnumret för den döde som identifieringsuppgift.</p>
+
+      <h3>Vad händer om dödsboet inte deklarerar?</h3>
+      <p>Skatteverket kan fastställa ett schablonmässigt skattebelopp (skönstaxering) och ta ut skattetillägg. Dödsbodelägarna kan i vissa fall bli personligt ansvariga om de förhalat processen utan godtagbart skäl.</p>
+
+      <h3>Behöver vi anlita en revisor eller redovisningskonsult?</h3>
+      <p>Det beror på dödsboets komplexitet. Har den döde haft enkla inkomster — pension, bankkonto — klarar dödsbodelägarna ofta deklarationen själva med Skatteverkets förtryckta material. Drev den döde ett företag, hade värdepapper i stora volymer, eller säljer dödsboet fastigheter — anlita en revisor eller redovisningskonsult.</p>
+
+      <div class="seo-cta">
+        <p>Håll koll på alla praktiska steg efter ett dödsfall — från bouppteckning till avslutat dödsbo</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./bankkonto-dodsfall.html">Bankkonto vid dödsfall</a> &nbsp;·&nbsp;
+      <a href="./salja-dodsbo.html">Sälja dödsbo</a> &nbsp;·&nbsp;
+      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/dodsbo-skulder.html
+++ b/dodsbo-skulder.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dödsbo skulder — vem betalar och vad händer om skulderna överstiger tillgångarna? | Efterplan</title>
+  <meta name="description" content="Arvingar ärver inte skulder i Sverige. Men dödsboets skulder måste betalas innan arvet fördelas. Guide 2026 om skulder i dödsbo, fordringsägare och överskuldade dödsbon.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/dodsbo-skulder.html">
+  <meta property="og:title" content="Dödsbo skulder — vem betalar den dödes skulder?">
+  <meta property="og:description" content="Arvingar ärver inte skulder. Men dödsboets skulder betalas innan arvet. Vad händer om skulderna överstiger tillgångarna? Komplett guide 2026.">
+  <meta property="og:url" content="https://efterplan.se/dodsbo-skulder.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Dödsbo skulder — vem betalar och vad händer om skulderna överstiger tillgångarna?",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-15",
+    "dateModified": "2026-04-15",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/dodsbo-skulder.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Ärver man skulder i Sverige?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Nej. Arvingar ärver inte skulder i Sverige. Skulder betalas av dödsboets tillgångar. Om tillgångarna inte räcker försvinner resten av skulden — borgenärerna kan inte kräva arvingarna personligen." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad händer om dödsboet har mer skulder än tillgångar?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Om skulderna överstiger tillgångarna (insolvent dödsbo) ansöker dödsboet om konkurs eller dödsboanmälan. Skatteverket kan göra en dödsboanmälan istället för bouppteckning om tillgångarna inte räcker till begravningskostnader. Arvingarna får ingenting och förlorar heller inget eget." }
+      },
+      {
+        "@type": "Question",
+        "name": "Kan en bank kräva dödsboet på lån?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja. Banker och andra fordringsägare har rätt att kräva betalning från dödsboet. Dödsboet är skyldigt att betala skulder i rätt ordning — begravningskostnader och boutredningskostnader prioriteras, sedan övriga skulder. Om tillgångarna inte räcker betalas skulder proportionellt." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad händer med gemensamma lån när en make dör?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Vid gemensamma lån (t.ex. bolån med båda makarna som låntagare) kvarstår den efterlevande makens betalningsskyldighet för hela lånet. Den dödes del av lånet betalas av dödsboet eller ingår i bodelningen. Kontakta banken omgående vid ett dödsfall om ni har gemensamma lån." }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Dödsbo skulder — vem betalar och vad händer?</h1>
+
+      <p>En av de vanligaste frågorna vid ett dödsfall: <em>ärver jag den dödes skulder?</em> Det korta svaret är <strong>nej</strong> — i Sverige ärver arvingar inte personliga skulder. Men det finns viktiga nyanser att känna till. Dödsboets skulder betalas av dödsboets tillgångar innan arvet fördelas, och i vissa situationer kan arvingar bli personligt ansvariga — om de agerat fel.</p>
+
+      <h2>Grundprincipen — skulder stannar i dödsboet</h2>
+      <p>När en person dör tar dödsboet över alla tillgångar <em>och</em> skulder. Dödsboet är ett eget rättssubjekt som ägs gemensamt av arvingarna. Skulder betalas ur dödsboets tillgångar. Om tillgångarna räcker betalas skulderna och resten fördelas som arv. Om tillgångarna <em>inte</em> räcker — se avsnittet om överskuldsatta dödsbon nedan.</p>
+      <p>Arvingarna ärver aldrig mer skuld än vad dödsboets tillgångar täcker. En arvinges egna tillgångar kan aldrig tas i anspråk för den dödes skulder — om arvingen agerat korrekt.</p>
+
+      <h2>Vilka skulder ingår i dödsboet?</h2>
+      <p>Alla skulder som den döde hade vid dödsfallet ingår i dödsboet:</p>
+      <ul>
+        <li>Bolån och övriga banklån</li>
+        <li>Kreditkortsskulder och konsumtionslån</li>
+        <li>Skatteskulder (inkomstskatt, mervärdesskatt)</li>
+        <li>Hyresskulder</li>
+        <li>Obetalda räkningar (el, telefon, prenumerationer)</li>
+        <li>Skulder till privatpersoner</li>
+        <li>Borgensåtaganden (om den döde stod som borgensman)</li>
+      </ul>
+
+      <h2>Skulder prioriteras — i rätt ordning</h2>
+      <p>Dödsboet betalar skulder i en prioriterad ordning. Inte alla skulder är jämbördiga:</p>
+      <ol>
+        <li><strong>Begravningskostnader</strong> — dessa har högsta prioritet och betalas alltid först, oavsett dödsboets ställning.</li>
+        <li><strong>Boutredningskostnader</strong> — arvode för boutredningsman, mäklare, bouppteckningskostnader och liknande.</li>
+        <li><strong>Skatteskulder</strong> — Skatteverkets fordringar har hög prioritet.</li>
+        <li><strong>Övriga skulder</strong> — banker, kreditbolag, privatpersoner och andra fordringsägare.</li>
+      </ol>
+      <p>Om tillgångarna inte räcker till alla skulder betalas de i denna ordning — lägre prioriterade fordringsägare kan få noll.</p>
+
+      <h2>Gemensamma lån — vad händer?</h2>
+      <p>Gemensamma lån (framför allt bolån med båda makarna som medlåntagare) kräver särskild uppmärksamhet:</p>
+      <ul>
+        <li>Den <strong>efterlevande make/sambo</strong> som är medlåntagare kvarstår som ensam ansvarig för hela lånet efter dödsfall.</li>
+        <li>Den dödes del av lånet ingår i dödsboet som en skuld.</li>
+        <li>Vid bodelning kan bolånet fördelas — men banken behöver godkänna eventuell omläggning av lånet.</li>
+        <li>Kontakta banken omedelbart efter dödsfallet för att gå igenom gemensamma krediter.</li>
+      </ul>
+
+      <h2>Borgen — om den döde var borgensman</h2>
+      <p>Om den döde hade ett borgensåtagande (stod som borgensman för annans lån) avslutas borgensåtagandet vanligtvis inte automatiskt vid dödsfall. Dödsboet kan bli ansvarigt för borgensbeloppet om huvudlåntagaren inte betalar. Kontrollera om det finns borgensavtal i dödsboet.</p>
+
+      <h2>Vad är ett överskuldsatt dödsbo?</h2>
+      <p>Om dödsboets skulder överstiger tillgångarna är dödsboet <strong>insolvent</strong> — överskuldsatt. Det finns då inte tillräckligt med pengar för att betala alla skulder. I det läget kan:</p>
+      <ul>
+        <li><strong>Dödsboet ansöka om konkurs</strong> — en konkursförvaltare utses och disponibla tillgångar fördelas till fordringsägarna i prioritetsordning. Arvingarna får ingenting.</li>
+        <li><strong>Dödsboanmälan göras</strong> — om tillgångarna inte ens täcker begravningskostnaderna kan Skatteverket göra en förenklad dödsboanmälan istället för bouppteckning. Det innebär att dödsboet avskrivs utan formellt skifte.</li>
+      </ul>
+
+      <h2>När kan en arvinge bli personligt ansvarig?</h2>
+      <p>Normalt har arvingar inget personligt ansvar för dödsboets skulder. Men det finns undantag:</p>
+      <ul>
+        <li><strong>Otillbörliga utbetalningar:</strong> Om en arvinge tar ut pengar från dödsboet eller gör betalningar utan att skulder finns täckta kan hen bli personligt ansvarig mot fordringsägarna.</li>
+        <li><strong>Oacceptabelt dröjsmål med bouppteckning:</strong> Om bouppteckning inte görs i tid (inom 3 månader) och fordringsägare skadas av dröjsmålet kan skadeståndsansvar uppstå.</li>
+        <li><strong>Kvittning av egna fordringar:</strong> En arvinge som också är fordringsägare (t.ex. har lånat ut pengar till den döde) ska inte betala sig själv utan att följa prioritetsordningen.</li>
+      </ul>
+      <p>Agera alltid i enighet med övriga dödsbodelägare och betala inte ut arv innan skulder är betalda.</p>
+
+      <h2>Praktiska råd</h2>
+      <ul>
+        <li><strong>Blockera inga betalningar.</strong> Löpande skull (el, hyra, försäkring) betalas av dödsboet tills avtalen är avslutade.</li>
+        <li><strong>Säg upp avtal och prenumerationer.</strong> Abonnemang på tidningar, streamingtjänster och liknande bör sägas upp snabbt för att undvika onödiga kostnader.</li>
+        <li><strong>Kontakta banker och kreditgivare.</strong> Informera om dödsfallet. Be om en aktuell skuldsaldo och ta reda på om det finns skulder som inte syns på ett vanligt kontoutdrag.</li>
+        <li><strong>Kolla om den döde hade skulder hos Kronofogden.</strong> Du kan göra en skuldenförfrågan hos Kronofogden för att ta reda på om det finns utmätningsbara skulder.</li>
+        <li><strong>Betala inte arv innan alla skulder är reglerade.</strong> Vänta med arvskiftet tills ni vet att alla skulder är betala.</li>
+      </ul>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Kan en kreditgivare kräva mig som arvinge på den dödes skuld?</h3>
+      <p>Nej, inte normalt. Du som arvinge ärver inte personliga skulder. Kreditgivaren kan bara kräva betalning ur dödsboets tillgångar. Om du dock har tagit ut pengar från dödsboet innan skulder var betalda kan du bli personligt ansvarig upp till det belopp du tagit ut.</p>
+
+      <h3>Vad händer med en hyresrätt om den döde hade hyresskuld?</h3>
+      <p>Hyresskulden är en skuld i dödsboet och ska betalas. Hyresvärden kan kräva betalning av dödsboet. Om skulden inte betalas kan hyresrätten sägas upp, och det kan påverka möjligheten för en närstående att överta hyresavtalet.</p>
+
+      <h3>Är jag skyldig att betala begravningen om dödsboet saknar pengar?</h3>
+      <p>Nej, det finns ingen juridisk skyldighet för arvingar att betala begravning ur egna medel. Om dödsboet saknar pengar kan kommunen betala en enkel begravning. Kontakta socialtjänsten i kommunen om dödsboet är utan medel.</p>
+
+      <div class="seo-cta">
+        <p>Håll ordning på dödsboets tillgångar och skulder — komplett checklista</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-deklaration.html">Deklarera dödsbo</a> &nbsp;·&nbsp;
+      <a href="./bankkonto-dodsfall.html">Bankkonto vid dödsfall</a> &nbsp;·&nbsp;
+      <a href="./tomma-dodsbo.html">Tömma dödsbo</a> &nbsp;·&nbsp;
+      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/efterlevandepension.html
+++ b/efterlevandepension.html
@@ -165,14 +165,14 @@
   <footer class="seo-footer">
     <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
     <p class="seo-footer-links">
+      <a href="./sambo-arv.html">Sambo och arv</a> &nbsp;·&nbsp;
+      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
       <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
-      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
       <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
       <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
-      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
-      <a href="./dodsbo-bostadsratt.html">Dödsbo bostadsrätt</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
       <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
-      <a href="./vad-kostar-en-begravning.html">Vad kostar en begravning?</a>
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
     </p>
   </footer>
 </body>

--- a/fullmakt-dodsbo.html
+++ b/fullmakt-dodsbo.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fullmakt dödsbo — vem kan företräda dödsboet? | Efterplan</title>
+  <meta name="description" content="Hur utfärdar man fullmakt för ett dödsbo? Vem kan fatta beslut och företräda dödsboet? Guide till dödsboets befogenheter och fullmaktens juridiska krav.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/fullmakt-dodsbo.html">
+  <meta property="og:title" content="Fullmakt dödsbo — vem kan företräda dödsboet?">
+  <meta property="og:description" content="Alla dödsbodelägare behöver inte vara med i varje beslut. Med en fullmakt kan en delägare agera å de andras vägnar. Lär dig hur fullmakt i dödsbo fungerar.">
+  <meta property="og:url" content="https://efterplan.se/fullmakt-dodsbo.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Fullmakt dödsbo — vem kan företräda dödsboet?",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-15",
+    "dateModified": "2026-04-15",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/fullmakt-dodsbo.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Kan man använda en befintlig fullmakt efter att fullmaktsgivaren dött?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Nej. En fullmakt upphör automatiskt att gälla när fullmaktsgivaren dör. Det finns inget undantag — inte ens en framtidsfullmakt gäller för dödsboet. För att handla å dödsboets vägnar krävs en ny fullmakt utfärdad av dödsbodelägarna gemensamt." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vem kan utfärda fullmakt för ett dödsbo?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Alla dödsbodelägare gemensamt kan utfärda fullmakt för att en av dem eller en utomstående (t.ex. en jurist) ska företräda dödsboet. Det räcker inte att en enskild delägare utfärdar fullmakt på egen hand — alla måste skriva under." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad kan man göra med en dödsbosfullmakt?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Med en dödsbosfullmakt kan fullmäktigen utföra specifika uppdrag å dödsboets vägnar: teckna dödsboets konton, skriva under deklarationer, genomföra fastighetsförsäljning, kontakta myndigheter och liknande. Fullmakten kan vara generell eller begränsad till ett specifikt uppdrag." }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Fullmakt dödsbo — vem kan företräda dödsboet?</h1>
+
+      <p>När en person dör kan det vara opraktiskt om alla arvingar måste skriva under varje dokument och vara med vid varje möte. Lösningen är en <strong>fullmakt för dödsboet</strong> — ett juridiskt dokument som ger en person rätt att agera å dödsboets vägnar. Men det finns viktiga regler att känna till, inklusive en regel som chockar många: <em>en befintlig fullmakt slutar gälla automatiskt när fullmaktsgivaren dör.</em></p>
+
+      <h2>Fullmakten upphör vid dödsfall</h2>
+      <p>En av de vanligaste missuppfattningarna i dödsboförvaltning är att en befintlig fullmakt — t.ex. en bankfullmakt eller en generell fullmakt — fortsätter gälla efter dödsfallet. Det stämmer inte.</p>
+      <p>Enligt avtalslagen upphör en fullmakt automatiskt när fullmaktsgivaren dör. Det gäller:</p>
+      <ul>
+        <li>Bankfullmakter</li>
+        <li>Generella fullmakter</li>
+        <li>Framtidsfullmakter (som gäller vid nedsatt beslutsförmåga, men upphör vid dödsfall)</li>
+        <li>Alla andra former av fullmakter</li>
+      </ul>
+      <p>En bank eller myndighet som accepterar en fullmakt utfärdad av den döde efter dödsfallet gör fel. Informera omgående bank och berörda parter om dödsfallet.</p>
+
+      <h2>Vem kan företräda dödsboet?</h2>
+      <p>Dödsboet ägs gemensamt av <strong>dödsbodelägarna</strong> — arvingar och testamentstagare. Alla dödsbodelägare har rätt att delta i förvaltningen och beslut fattas normalt gemensamt (enhälligt). Det finns tre sätt att organisera detta:</p>
+
+      <h3>1. Alla dödsbodelägare agerar gemensamt</h3>
+      <p>Det enklaste och vanligaste: alla dödsbodelägare skriver under alla dokument och fattar alla beslut gemensamt. Funkar bra när det är få delägare och god kommunikation.</p>
+
+      <h3>2. Fullmakt — en delägare agerar för alla</h3>
+      <p>Dödsbodelägarna utfärdar gemensamt en fullmakt till en av sig (eller till en utomstående) som får agera å dödsboets vägnar. Fullmäktigen kan då t.ex.:</p>
+      <ul>
+        <li>Öppna dödsboets bankkonto och hantera ekonomi</li>
+        <li>Kontakta Skatteverket och myndigheter</li>
+        <li>Anlita mäklare och genomföra fastighetsförsäljning</li>
+        <li>Underteckna bouppteckning och deklaration</li>
+        <li>Avsluta abonnemang och prenumerationer</li>
+      </ul>
+
+      <h3>3. Testamentsexekutor</h3>
+      <p>Om den döde utsett en <strong>testamentsexekutor</strong> i testamentet har den personen ett formellt mandat att sköta dödsboets förvaltning. Testamentsexekutorn behöver inte fullmakt från dödsbodelägarna — mandatet kommer direkt från testamentet. Exekutorn har dock ingen rätt att genomföra arvskiftet utan delägarnas samtycke.</p>
+
+      <h2>Hur skriver man en fullmakt för dödsboet?</h2>
+      <p>En fullmakt för dödsbo behöver inte ha en speciell form, men bör innehålla:</p>
+      <ul>
+        <li>Datum och ort</li>
+        <li>Den dödes fullständiga namn och personnummer</li>
+        <li>Namnen på alla dödsbodelägare som utfärdar fullmakten</li>
+        <li>Fullmäktigens fullständiga namn och personnummer</li>
+        <li>Tydlig beskrivning av vad fullmäktigen har rätt att göra (specifik eller generell)</li>
+        <li>Underskrifter av <strong>alla dödsbodelägare</strong></li>
+      </ul>
+      <p>Exempelmening: <em>"Vi undertecknade, dödsbodelägare i dödsboet efter [den dödes namn], personnummer XXXXXX-XXXX, bemyndigar härmed [fullmäktigens namn], personnummer XXXXXX-XXXX, att å dödsboets vägnar [specificera uppdraget]."</em></p>
+
+      <h2>Bankärenden efter dödsfall — vad gäller?</h2>
+      <p>Banken fryser normalt den dödes konton när de informeras om dödsfallet. Det finns dock undantag:</p>
+      <ul>
+        <li><strong>Löpande kostnader:</strong> Dödsboet kan använda medel på kontot för att betala begravningskostnader och andra nödvändiga löpande kostnader (hyra, el, begravning) även utan formell bouppteckning.</li>
+        <li><strong>Gemensamma konton:</strong> Om kontot är gemensamt (båda makarna på kontot) kan den efterlevande maken normalt fortsätta använda sin del.</li>
+        <li><strong>Bankfullmakt upphör:</strong> Som nämnts ovan gäller inga gamla fullmakter efter dödsfall.</li>
+      </ul>
+      <p>Läs mer om vad som händer med bankkonton vid dödsfall i vår guide om <a href="./bankkonto-dodsfall.html">bankkonto vid dödsfall</a>.</p>
+
+      <h2>Boutredningsman — när ingen är överens</h2>
+      <p>Om dödsbodelägarna inte kan komma överens om vem som ska sköta dödsboet eller hur det ska förvaltas kan vilken delägare som helst ansöka hos tingsrätten om att en <strong>boutredningsman</strong> utses. Boutredningsmannen tar då över förvaltningen med mandat att genomföra dödsboets avveckling — utan att alla delägare behöver vara eniga.</p>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Kan ett barn under 18 år vara dödsbodelägare?</h3>
+      <p>Ja. Om ett minderårigt barn är arvinge är barnet dödsbodelägare. Barnets förälder (eller god man) agerar å barnets vägnar vid bouppteckning och arvskifte. En underårig kan inte underteckna avtal på egen hand — förmyndaren gör det.</p>
+
+      <h3>Kan fullmakten begränsas till ett specifikt ärende?</h3>
+      <p>Ja, och det rekommenderas ofta. Istället för en generell fullmakt kan ni utfärda en specifik fullmakt för t.ex. "försäljning av fastigheten på [adress]" eller "hantering av dödsboets bankkonton hos Swedbank". Specifika fullmakter minskar risken för missbruk.</p>
+
+      <h3>Måste fullmakten bevittnas eller registreras?</h3>
+      <p>Det finns inget lagkrav på bevittning eller registrering av en dödsbosfullmakt. Men banker och myndigheter kan ha egna krav — kontakta den aktuella instansen i förväg för att veta vad de kräver. Fastighetstransaktioner kräver i regel att fullmakten är skriftlig och undertecknad av alla delägare.</p>
+
+      <div class="seo-cta">
+        <p>Håll koll på alla steg i dödsboprocessen — komplett checklista och guide</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./bankkonto-dodsfall.html">Bankkonto vid dödsfall</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
+      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
+      <a href="./tomma-dodsbo.html">Tömma dödsbo</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/salja-dodsbo.html
+++ b/salja-dodsbo.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sälja dödsbo — fastighet, bostadsrätt och lösöre 2026 | Efterplan</title>
+  <meta name="description" content="Hur säljer man ett dödsbo? Alla arvingar måste vara överens. Lär dig processen för att sälja fastighet, bostadsrätt och lösöre ur ett dödsbo — steg för steg.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/salja-dodsbo.html">
+  <meta property="og:title" content="Sälja dödsbo — fastighet, bostadsrätt och lösöre 2026">
+  <meta property="og:description" content="Alla dödsbodelägare måste samtycka för att sälja egendom ur ett dödsbo. Steg-för-steg guide för att sälja fastighet, lägenhet och lösöre.">
+  <meta property="og:url" content="https://efterplan.se/salja-dodsbo.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Sälja dödsbo — fastighet, bostadsrätt och lösöre 2026",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-15",
+    "dateModified": "2026-04-15",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/salja-dodsbo.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Kan en arvinge sälja dödsboets fastighet utan de andras samtycke?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Nej. Alla dödsbodelägare måste vara överens om att sälja en fastighet. Om delägarna inte kommer överens kan en boutredningsman utses av tingsrätten som då kan genomföra försäljningen." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vem skriver under köpekontraktet för dödsboets fastighet?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Alla dödsbodelägare måste skriva under köpekontraktet, alternativt utfärda fullmakt till en av delägarna. Om det finns en testamentsexekutor kan denne i vissa fall genomföra försäljningen." }
+      },
+      {
+        "@type": "Question",
+        "name": "Betalar dödsboet skatt vid försäljning av fastighet?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja. Dödsboet betalar 22 % kapitalvinstskatt på vinsten vid försäljning av fastighet. Vinsten beräknas som försäljningspris minus ursprungligt anskaffningsvärde och avdragsgilla förbättringsutgifter. Skatten betalas av dödsboet innan arvet fördelas." }
+      },
+      {
+        "@type": "Question",
+        "name": "Kan man sälja dödsboets fastighet innan bouppteckning är klar?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Tekniskt möjligt, men starkt avrådd. Bouppteckningen fastställer vem som är dödsbodelägare — utan den är det oklart vem som har rätt att underteckna. De flesta mäklare kräver att bouppteckning är inlämnad till Skatteverket innan försäljning." }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Sälja dödsbo — fastighet, bostadsrätt och lösöre</h1>
+
+      <p>Att sälja egendom ur ett dödsbo är en av de vanligaste och potentiellt mest komplicerade uppgifterna i dödsboförvaltningen. Oavsett om det gäller en fastighet, en bostadsrätt, en bil eller ett helt bohag gäller samma grundprincip: <strong>alla dödsbodelägare måste vara överens</strong>. Den här guiden går igenom reglerna, processen och vad du kan göra om ni inte är eniga.</p>
+
+      <h2>Grundregeln — alla dödsbodelägare måste samtycka</h2>
+      <p>Dödsboet är en juridisk person som ägs gemensamt av samtliga dödsbodelägare — arvingar och testamentstagare. Ingen enskild delägare kan på egen hand besluta om att sälja dödsboets egendom. Det krävs <strong>enighet</strong>.</p>
+      <p>Det innebär praktiskt att:</p>
+      <ul>
+        <li>Alla dödsbodelägare måste godkänna försäljning av fastigheter, bostadsrätter, fordon och andra värdefulla tillgångar.</li>
+        <li>Alla måste skriva under köpekontraktet, eller utfärda skriftlig fullmakt till en av delägarna.</li>
+        <li>En delägare som vägrar att sälja kan blockera hela processen.</li>
+      </ul>
+
+      <h2>Sälja fastighet ur dödsbo</h2>
+      <p>En fastighet (villa, fritidshus, jordbruksfastighet) är ofta dödsboets mest värdefulla tillgång — och den som kräver mest planering. Så går det till:</p>
+
+      <h3>Steg 1 — Vänta tills bouppteckning är registrerad</h3>
+      <p>Bouppteckningen fastställer vilka dödsbodelägarna är och ska vara registrerad hos Skatteverket innan försäljning genomförs. Utan registrerad bouppteckning vet inte Lantmäteriet vem som har rätt att sälja fastigheten. De flesta mäklare kräver att bouppteckning är inlämnad.</p>
+
+      <h3>Steg 2 — Värdering</h3>
+      <p>Anlita en mäklare för en marknadsvärdebedömning. Det är klokt att ta in minst två bedömningar. Värderingen behövs dels för att dödsbodelägarna ska kunna fatta ett informerat beslut, dels för att kunna beräkna kapitalvinsten till skattedeklarationen.</p>
+
+      <h3>Steg 3 — Alla undertecknar eller utfärdar fullmakt</h3>
+      <p>Samtliga dödsbodelägare måste skriva under uppdragsavtalet med mäklaren och köpekontraktet. Om en delägare inte kan närvara kan hen utfärda en skriftlig fullmakt till en annan delägare.</p>
+
+      <h3>Steg 4 — Försäljningen genomförs</h3>
+      <p>Mäklaren hanterar visningar, bud och köpekontrakt på normalt sätt. Vid tillträdet fördelas köpeskillingen (efter mäklararvode och eventuella skulder) till dödsboets konto.</p>
+
+      <h3>Steg 5 — Skattedeklaration</h3>
+      <p>Dödsboet deklarerar kapitalvinsten i årets inkomstdeklaration. Kapitalvinstskatten är <strong>22 %</strong> av vinsten (fastigheter) respektive <strong>22 %</strong> (bostadsrätter). Skatten betalas av dödsboets medel.</p>
+
+      <h2>Sälja bostadsrätt ur dödsbo</h2>
+      <p>Processen för bostadsrätt liknar fastighetsförsäljning men med några skillnader:</p>
+      <ul>
+        <li>Bostadsrättsföreningen måste godkänna den nya köparen (medlemsansökan).</li>
+        <li>Alla dödsbodelägare måste underteckna överlåtelseavtalet.</li>
+        <li>Kapitalvinst beskattas med 22 % på vinsten (beräknat på insatsen plus eventuella tilläggsavgifter och avdragsgilla förbättringsutgifter).</li>
+        <li>Månadsavgiften betalas av dödsboet fram till tillträdesdagen.</li>
+      </ul>
+      <p>Läs mer om specifika regler för bostadsrätt i dödsbo i vår guide om <a href="./dodsbo-bostadsratt.html">dödsbo och bostadsrätt</a>.</p>
+
+      <h2>Sälja lösöre — möbler, bil, smycken</h2>
+      <p>Lösöre (möbler, husgeråd, fordon, konst, smycken) kan säljas på olika sätt, beroende på värdet:</p>
+      <ul>
+        <li><strong>Auktionshus</strong> — Bukowskis, Stockholms Auktionsverk, Auctionet. Passar konst, silver, smycken, antikviteter. Provision 15–25 %.</li>
+        <li><strong>Blocket / Facebook Marketplace</strong> — effektivt för möbler och elektronik av lägre värde.</li>
+        <li><strong>Dödsbouppköpare</strong> — firmor som köper hela bohaget. Enkelt men pris under marknadsvärde.</li>
+        <li><strong>Dödsboauktion</strong> — annonseras öppet och lockar budgivare. Kan ge bra priser för större samlingar.</li>
+      </ul>
+      <p>Pengar från försäljning tillhör dödsboet och ska inte gå direkt till den person som sköter försäljningen.</p>
+
+      <h2>Kapitalvinstskatt vid försäljning</h2>
+      <p>Dödsboet är ett eget skattesubjekt och beskattas för kapitalvinster. Vid försäljning av:</p>
+      <ul>
+        <li><strong>Fastighet:</strong> 22 % skatt på vinsten. Vinst = Försäljningspris − Anskaffningsvärde (ursprungligt köppris) − förbättringsutgifter − mäklarkostnad.</li>
+        <li><strong>Bostadsrätt:</strong> 22 % skatt på vinsten. Vinst = Försäljningspris − Insats − tilläggsavgifter − avdragsgilla förbättringsutgifter − mäklarkostnad.</li>
+        <li><strong>Aktier och fonder:</strong> 30 % skatt på vinsten.</li>
+        <li><strong>Lösöre (möbler, fordon m.m.):</strong> Kapitalvinst kan uppstå men är sällan aktuell för begagnat lösöre som säljs under ursprungligt inköpspris.</li>
+      </ul>
+      <p>Skatten betalas av dödsboets medel innan arvet fördelas. Läs mer om <a href="./arvsskatt.html">skatter vid arv och dödsbo</a>.</p>
+
+      <h2>Om delägarna inte är eniga</h2>
+      <p>Om dödsbodelägarna inte kan komma överens om försäljning finns två vägar:</p>
+
+      <h3>Boutredningsman</h3>
+      <p>Vilken dödsbodelägare som helst kan ansöka hos tingsrätten om att en <strong>boutredningsman</strong> utses. Boutredningsmannen tar över förvaltningen och kan genomföra försäljning av dödsboets tillgångar utan att alla delägare är överens. Kostnaderna betalas av dödsboet.</p>
+
+      <h3>Skiftesman</h3>
+      <p>Om oenigheten gäller själva arvskiftet kan tingsrätten utse en <strong>skiftesman</strong> som genomför skifte med bindande verkan för alla parter.</p>
+      <p>Att anlita boutredningsman eller skiftesman är ofta dyrare och tar längre tid än att komma överens. Försök alltid lösa tvisterna i godo innan ni vänder er till domstol.</p>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Kan vi sälja fastigheten snabbt för att betala begravningskostnader?</h3>
+      <p>Dödsboet kan betala begravningskostnader och löpande utgifter (hyra, el, försäkringar) ur befintliga likvida medel — bankkonton och liknande. Om likvida medel saknas kan en snabb försäljning vara nödvändig, men processen tar ändå normalt minst 2–3 månader.</p>
+
+      <h3>Måste vi anlita mäklare för att sälja dödsboets fastighet?</h3>
+      <p>Det finns inget lagkrav på mäklare, men det är starkt rekommenderat. En registrerad fastighetsmäklare ansvarar för att överlåtelsen går rätt till och att köpekontraktet uppfyller alla krav. En privat försäljning ("under hand") kräver att dödsbodelägarna själva håller koll på alla juridiska formaliteter.</p>
+
+      <h3>Kan vi sälja till en arvinge till underpris?</h3>
+      <p>Tekniskt möjligt om alla delägare godkänner det. Men om en arvinge köper en tillgång under marknadsvärdet kan Skatteverket betrakta mellanskillnaden som ett förskott på arv, och det kan skapa skattemässiga konsekvenser. Anlita alltid en jurist om ni överväger detta.</p>
+
+      <div class="seo-cta">
+        <p>Håll koll på hela dödsboprocessen — bouppteckning, arvskifte och försäljning</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./tomma-dodsbo.html">Tömma dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-bostadsratt.html">Dödsbo bostadsrätt</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/sambo-arv.html
+++ b/sambo-arv.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sambo och arv — ärver en sambo automatiskt? | Efterplan</title>
+  <meta name="description" content="En sambo ärver ingenting automatiskt. Utan testamente har sambor noll arvsrätt i Sverige. Lär dig vad sambolagen täcker och hur du skyddar din partner.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/sambo-arv.html">
+  <meta property="og:title" content="Sambo och arv — ärver en sambo automatiskt?">
+  <meta property="og:description" content="Utan testamente ärver en sambo ingenting i Sverige. Sambolagen täcker bara gemensam bostad och bohag — inte pengar, aktier eller övriga tillgångar.">
+  <meta property="og:url" content="https://efterplan.se/sambo-arv.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Sambo och arv — ärver en sambo automatiskt?",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-15",
+    "dateModified": "2026-04-15",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/sambo-arv.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Ärver en sambo automatiskt om partnern dör?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Nej. En sambo har ingen automatisk arvsrätt i Sverige. Utan testamente tillfaller arvet den dödes legala arvingar — barn, föräldrar eller syskon — och sambons kvar-lever eventuellt utan arv." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad täcker sambolagen vid dödsfall?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Sambolagen ger den efterlevande sambons rätt att begära bodelning av den gemensamma bostaden och bohaget (möbler, husgeråd). Det är inte arv — det är en uppdelning av gemensamma ägodelar. Pengarna på bankkontot, aktier, bil och övriga tillgångar ingår inte." }
+      },
+      {
+        "@type": "Question",
+        "name": "Hur skyddar man sin sambo arvsrättsligt?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Det enda sättet att ge sin sambo arvsrätt är att upprätta ett testamente. I testamentet kan du ange att sambons ska ärva hela eller delar av kvarlåtenskapen. Tänk på att bröstarvingar (barn) alltid har rätt till sin laglott — hälften av den arvslott de normalt fått." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad är skillnaden mellan sambo och gift när det gäller arv?",
+        "acceptedAnswer": { "@type": "Answer", "text": "En gift make ärver automatiskt hela kvarlåtenskapen med fri förfoganderätt (om det inte finns barn från tidigare relationer). En sambo ärver ingenting utan testamente. Det är en avgörande skillnad som många inte känner till." }
+      },
+      {
+        "@type": "Question",
+        "name": "Kan en sambo bo kvar i gemensam bostad efter dödsfall?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Den efterlevande sambons har rätt att begära bodelning och kan i vissa fall behålla bostaden om den bidrar med hälften av bostadens värde till dödsboet. Om bostaden ägs ensamt av den döde utan testamente tillfaller den dödsboet och arvingarna." }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Sambo och arv — ärver en sambo automatiskt?</h1>
+
+      <p>Det är en av de vanligaste juridiska missuppfattningarna i Sverige: att sambor automatiskt ärver varandra. <strong>Det stämmer inte.</strong> En sambo har noll automatisk arvsrätt. Om din partner dör utan testamente tillfaller arvet hans eller hennes legala arvingar — och du kan stå helt utan skydd. Den här guiden förklarar exakt vad lagen säger och vad du behöver göra för att skydda dig och din sambo.</p>
+
+      <h2>Sambolagen ger inte arvsrätt</h2>
+      <p>Sambolagen (2003:376) reglerar vad som händer med <em>gemensamt förvärvad</em> bostad och bohag när ett samboförhållande upphör — oavsett om det beror på separation eller dödsfall. Men sambolagen är <strong>inte</strong> en arvsregel. Den ger den efterlevande sambons rätt att begära bodelning av:</p>
+      <ul>
+        <li>Den gemensamma bostaden (om den köpts för gemensamt bruk)</li>
+        <li>Bohaget — möbler, vitvaror, husgeråd och liknande föremål avsedda för gemensamt bruk</li>
+      </ul>
+      <p>Det innebär att sambons kan begära att få 50 % av bostadens nettovärde och hälften av bohaget. Men resten — bankkonton, aktier, bil, fritidshus, smycken, övrig egendom — ingår inte i bodelningen och tillfaller dödsboet och de legala arvingarna.</p>
+
+      <h2>Arvsordningen när sambor inte är gifta</h2>
+      <p>Enligt ärvdabalken (1958:637) fördelas arvet i tre arvsklasser om det saknas testamente:</p>
+      <ol>
+        <li><strong>Arvsklass 1:</strong> Bröstarvingar — barn och barnbarn. De ärver allt i lika delar.</li>
+        <li><strong>Arvsklass 2:</strong> Föräldrar (och om de är döda: syskon och syskonbarn).</li>
+        <li><strong>Arvsklass 3:</strong> Far- och morföräldrar (och deras barn — mostrar, farbröder).</li>
+      </ol>
+      <p>En sambo befinner sig utanför dessa arvsklasser. Om din partner dör utan barn och utan testamente ärver dina partners föräldrar hela kvarlåtenskapen — och du får ingenting utöver din rätt till bodelning.</p>
+
+      <h2>Jämförelse: sambo vs. gift</h2>
+      <p>Skillnaden i arvsrättslig ställning är dramatisk:</p>
+      <ul>
+        <li><strong>Gift make:</strong> Ärver hela kvarlåtenskapen med fri förfoganderätt, under förutsättning att det inte finns särkullbarn (barn från tidigare relationer). Gifta makar har ett automatiskt skydd i lagen.</li>
+        <li><strong>Sambo:</strong> Ärver ingenting utan testamente. Har endast rätt till bodelning av gemensam bostad och bohag.</li>
+      </ul>
+      <p>Det är en skillnad som chockar många par som levt tillsammans i tio, tjugo eller trettio år — men juridiken bryr sig inte om tidens längd.</p>
+
+      <h2>Hur du skyddar din sambo med testamente</h2>
+      <p>Det enda juridiskt säkra sättet att ge din sambo arvsrätt är ett <strong>testamente</strong>. I testamentet anger du att din sambo ska ärva hela eller en del av din kvarlåtenskap. Några viktiga saker att tänka på:</p>
+      <ul>
+        <li><strong>Laglotten kan inte testamenteras bort:</strong> Om du har barn (bröstarvingar) har de alltid rätt till sin laglott — hälften av den arvslott de normalt fått. Du kan alltså som mest testamentera bort halva din kvarlåtenskap om du har barn.</li>
+        <li><strong>Barnlösa kan ge allt:</strong> Har du inga bröstarvingar kan du testamentera hela din kvarlåtenskap till sambons, utan begränsningar.</li>
+        <li><strong>Formkrav måste uppfyllas:</strong> Testamentet ska vara skriftligt, underskrivet av dig och bevittnat av två oberoende vittnen som är närvarande samtidigt.</li>
+        <li><strong>Uppdatera om livet förändras:</strong> Testamentet bör ses över om du får barn, skiljer dig från din sambo, gifter om dig eller om din sambo dör.</li>
+      </ul>
+
+      <h2>Samboavtal — skyddar inte vid dödsfall</h2>
+      <p>Många blandar ihop samboavtal med testamente. Ett samboavtal reglerar vad som ska gälla vid <em>separation</em> — exempelvis att bodelning inte ska ske eller att specifik egendom ska undantas. Samboavtalet ger inte din sambo arvsrätt vid dödsfall. För arvsrättsligt skydd krävs alltid ett testamente.</p>
+
+      <h2>Praktiska steg — vad ni bör göra nu</h2>
+      <ol>
+        <li><strong>Skriv testamente.</strong> Kontakta en jurist eller skriv det själv med korrekt form (skriftligt, signerat, två vittnen). Kostnaden för juridisk hjälp är vanligtvis 1 500–4 000 kr.</li>
+        <li><strong>Tänk på laglotten.</strong> Om ni har barn från tidigare relationer — era egna eller särkullbarn — påverkar det hur mycket ni kan testamentera till varandra.</li>
+        <li><strong>Förvara testamentet säkert.</strong> Hemma i kassaskåp, hos en jurist, eller i Sveriges Begravningsbyråers Förbunds testamentsregister.</li>
+        <li><strong>Överväg livförsäkring med förmånstagare.</strong> En livförsäkring med din sambo som förmånstagare betalas ut direkt, utanför dödsboet, och påverkas inte av arvsreglerna.</li>
+      </ol>
+
+      <h2>Vad händer med gemensam bostad utan testamente?</h2>
+      <p>Antag att ni bor i en lägenhet som ni köpte gemensamt. Din partner dör utan testamente och ni har inga gemensamma barn. Din partners föräldrar är arvingar. Det sker då:</p>
+      <ul>
+        <li>Du har rätt att begära bodelning och behålla din halva av lägenheten.</li>
+        <li>Din partners halva ingår i dödsboet och tillfaller arvingarna (föräldrarna).</li>
+        <li>Om arvingarna vill sälja lägenheten kan du tvingas lösa ut dem eller flytta.</li>
+      </ul>
+      <p>Utan testamente finns inget som hindrar arvingarna från att kräva att lägenheten säljs — oavsett hur länge ni bott där.</p>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Vi har barn tillsammans — ärver jag som sambo då?</h3>
+      <p>Nej, inte automatiskt. Gemensamma barn ärver din partner i första hand (arvsklass 1). Du som sambo ärver fortfarande ingenting utan testamente. Barnen kan dock avstå sitt arv till förmån för dig, men det kräver aktiva åtgärder och är osäkert att räkna med.</p>
+
+      <h3>Kan vi lösa det med ett inbördes testamente?</h3>
+      <p>Ja. Sambor kan upprätta ett inbördes testamente där ni förklarar att den som lever längst ska ärva den som dör först. Det är en vanlig och effektiv lösning för sambor utan särkullbarn. Tänk på att båda måste underteckna var sitt testamente — ett gemensamt dokument räcker inte formellt.</p>
+
+      <h3>Vad händer om vi separerar — gäller testamentet fortfarande?</h3>
+      <p>Ja, ett testamente gäller tills det återkallas. Om ni separerar bör ni båda återkalla era respektive testamenten och eventuellt skriva nya. Till skillnad från äktenskapsskillnad upphävs inte ett testamente automatiskt av att samboförhållandet avslutas.</p>
+
+      <h3>Måste testamentet registreras?</h3>
+      <p>Nej, det finns inget lagkrav på registrering. Men att deponera det i testamentsregistret hos Sveriges Begravningsbyråers Förbund (kostnad ca 800–1 200 kr) gör att det hittas automatiskt vid dödsfall, oavsett om anhöriga känner till dess existens.</p>
+
+      <div class="seo-cta">
+        <p>Hantera dödsboet steg för steg — bouppteckning, arvskifte och alla praktiska uppgifter</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
+      <a href="./sarkullbarn.html">Särkullbarn och arv</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./arvsskatt.html">Arvsskatt Sverige</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/sarkullbarn.html
+++ b/sarkullbarn.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Särkullbarn och arv — rätt att ärva direkt och hur man skyddar efterlevande make | Efterplan</title>
+  <meta name="description" content="Särkullbarn har rätt att ärva direkt — de behöver inte vänta. Det kan lämna en efterlevande make i en svår situation. Lär dig hur arvsreglerna fungerar och vad du kan göra.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/sarkullbarn.html">
+  <meta property="og:title" content="Särkullbarn och arv — rätt att ärva direkt">
+  <meta property="og:description" content="Särkullbarn ärver direkt när en förälder dör — efterlevande make får ingenting av den del som tillhör särkullbarnen. Så fungerar reglerna och hur skyddar du din partner.">
+  <meta property="og:url" content="https://efterplan.se/sarkullbarn.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Särkullbarn och arv — rätt att ärva direkt och hur man skyddar efterlevande make",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-15",
+    "dateModified": "2026-04-15",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/sarkullbarn.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Vad är ett särkullbarn?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Särkullbarn är barn som en av makarna har från en tidigare relation — och som alltså inte är gemensamma barn med den nuvarande maken/makan. Särkullbarn har rätt att ärva sin biologiska förälder direkt, utan att behöva vänta på att styvföräldern också dör." }
+      },
+      {
+        "@type": "Question",
+        "name": "Ärver särkullbarn direkt när en förälder dör?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja. Särkullbarn har rätt att begära ut sitt arv direkt vid förälderns dödsfall. Gemensamma barn däremot ärver med uppskjuten rätt — de ärver när den siste föräldern dör. Det innebär att en efterlevande make kan stå utan sin del av kvarlåtenskapen om den döde hade särkullbarn." }
+      },
+      {
+        "@type": "Question",
+        "name": "Kan man skydda sin efterlevande make mot särkullbarnens arvsrätt?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Delvis. Genom testamente kan du ge din make/sambo rätt att sitta i orubbat bo — men särkullbarnen har alltid rätt till sin laglott (hälften av arvslotten) direkt. Det går alltså inte att testamentera bort laglotten, men man kan minimera likviditetsproblemet med rätt planering och livförsäkring." }
+      },
+      {
+        "@type": "Question",
+        "name": "Kan ett särkullbarn avstå sitt arv till förmån för efterlevande make?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja. Särkullbarn kan frivilligt välja att avstå sitt arv och i stället låta det tillfalla den efterlevande maken med fri förfoganderätt — precis som ett gemensamt barn. Särkullbarnet ärver då när den efterlevande maken dör. Det är ett frivilligt val som ingen kan tvingas till." }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Särkullbarn och arv — rätt att ärva direkt</h1>
+
+      <p>Sverige har ett av de mest komplexa arvsrättsliga systemen när det gäller ombildade familjer. Begreppet <strong>särkullbarn</strong> — barn från en tidigare relation — är centralt i hundratusentals svenska familjer, och konsekvenserna av reglerna kan vara dramatiska. En efterlevande make kan tvingas lämna ifrån sig halva sin kvarlåtenskap eller till och med sin bostad till särkullbarn vid sin partners dödsfall. Den här guiden förklarar reglerna, konsekvenserna och vad du kan göra för att planera klokt.</p>
+
+      <h2>Vad är ett särkullbarn?</h2>
+      <p>Särkullbarn är ett barn som en av parterna i ett äktenskap eller samboförhållande har från ett <em>tidigare</em> förhållande — och som alltså inte är gemensamt med den nuvarande partnern. Det spelar ingen roll om:</p>
+      <ul>
+        <li>Barnet är biologiskt eller adopterat</li>
+        <li>Barnet bor hemma eller är vuxet och utflyttat</li>
+        <li>Barnet har kontakt med föräldern eller inte</li>
+        <li>Det gäller ett äktenskap eller samboförhållande</li>
+      </ul>
+      <p>Avgörande är att barnet <em>inte</em> är gemensamt med den nuvarande partnern. Det gemensamma barnets arvsrätt är annorlunda — de ärver med <strong>uppskjuten rätt</strong>, vilket betyder att de väntar tills den siste föräldern dör.</p>
+
+      <h2>Hur arvsrätten skiljer sig — gemensamma barn vs. särkullbarn</h2>
+      <p>Ärvdabalken behandlar dessa två kategorier väldigt olika:</p>
+
+      <h3>Gemensamma barn</h3>
+      <p>Gemensamma barn ärver med uppskjuten rätt. Det innebär att när den förste föräldern dör ärver den efterlevande maken hela kvarlåtenskapen med <em>fri förfoganderätt</em> (inte full äganderätt). Gemensamma barn ärver inte förrän den siste föräldern också dör.</p>
+
+      <h3>Särkullbarn</h3>
+      <p>Särkullbarn ärver direkt. De har rätt att begära ut sin andel av arvet omedelbart när den biologiska föräldern dör — den efterlevande maken (deras styvförälder) har inte rätt att sitta på deras del.</p>
+
+      <h2>Räkneexempel — konsekvenserna i praktiken</h2>
+      <p>Antag att Maria och Björn är gifta. Björn har ett särkullbarn, Lisa, från ett tidigare äktenskap. Maria och Björn har inga gemensamma barn. Björns totala kvarlåtenskap är 2 000 000 kr.</p>
+      <ul>
+        <li>Lisa har rätt att ärva <strong>direkt</strong>: 2 000 000 kr ÷ 2 = 1 000 000 kr (arvslott). Laglotten är 500 000 kr (hälften av arvslotten) — det minsta Lisa kan kräva.</li>
+        <li>Om Björn har testamenterat allt till Maria kan Lisa ändå kräva sin laglott: 500 000 kr.</li>
+        <li>Utan testamente ärver Lisa hela 1 000 000 kr direkt, och Maria får 1 000 000 kr med fri förfoganderätt.</li>
+      </ul>
+      <p>Om Björns tillgångar är bundna i en fastighet kan Maria tvingas sälja huset för att betala Lisa hennes arvslott. Utan planering kan den efterlevande maken hamna i en omöjlig situation.</p>
+
+      <h2>Särkullbarnets laglott — kan den inte testamenteras bort</h2>
+      <p>Oavsett vad ett testamente säger har bröstarvingar — inklusive särkullbarn — alltid rätt till sin <strong>laglott</strong>. Laglotten är <em>hälften av arvslotten</em>. Arvslotten är vad barnet normalt fått om inget testamente funnits.</p>
+      <p>Har den döde ett barn ärver barnet normalt hela kvarlåtenskapen — arvslotten är 100 %. Laglotten är då 50 %. Har den döde två barn ärver varje barn 50 % — laglotten per barn är 25 %. Och så vidare.</p>
+      <p>Laglotten kan aldrig avtalas bort i förväg eller testamenteras bort utan barnets medverkan. Om testamentet inkräktar på laglotten kan barnet <strong>jämka testamentet</strong> inom sex månader från delgivning.</p>
+
+      <h2>Särkullbarnets val — vänta eller ta direkt</h2>
+      <p>Särkullbarnet kan välja:</p>
+      <ul>
+        <li><strong>Ta arvet direkt:</strong> Begär ut sin arvslott (eller minst laglotten) vid förälderns dödsfall.</li>
+        <li><strong>Skjuta upp arvet:</strong> Frivilligt avstå sitt arv med fri förfoganderätt till den efterlevande maken. Särkullbarnet ärver då när den maken dör, precis som ett gemensamt barn. Särkullbarnet har då rätt att ärva av den efterlevande makens kvarlåtenskap — det de avsagt sig plus sin andel av den siste makens tillgångar.</li>
+      </ul>
+      <p>Att skjuta upp arvet kan vara en generös gest gentemot styvföräldern. Särkullbarnet kan inte tvingas till det, men det är vanligare än många tror i familjer med god relation.</p>
+
+      <h2>Hur skyddar du din efterlevande make?</h2>
+      <p>Det finns flera sätt att planera för att minimera konsekvenserna:</p>
+
+      <h3>1. Testamente med villkor om fri förfoganderätt</h3>
+      <p>Skriv ett testamente som anger att din make ska sitta i orubbat bo — det vill säga att maken ska ha fri förfoganderätt över hela kvarlåtenskapen. Särkullbarnen har rätt att begära laglotten direkt, men allt utöver laglotten kan du testamentera till din make.</p>
+
+      <h3>2. Livförsäkring med make som förmånstagare</h3>
+      <p>En livförsäkring med din make som förmånstagare betalas ut utanför dödsboet — särkullbarnen har ingen rätt till den. Det är ett effektivt sätt att säkra din makes ekonomi utan att det påverkar arvsuppgörelsen.</p>
+
+      <h3>3. Äktenskapsförord</h3>
+      <p>Äktenskapsförord reglerar vad som är enskild egendom. Enskild egendom ingår inte i bodelningen vid dödsfall (bara vid skilsmässa) och kan inte testamenteras bort — men ett äktenskapsförord kan i kombination med testamente skapa en tydligare bild av tillgångarnas karaktär.</p>
+
+      <h3>4. Dialog med särkullbarnen</h3>
+      <p>I familjer med god relation är den bästa lösningen ofta en öppen dialog. Särkullbarn som vet om situationen kan välja att skjuta upp arvet frivilligt — en generositet som kan göra stor skillnad för styvföräldern.</p>
+
+      <h2>Om det finns både gemensamma barn och särkullbarn</h2>
+      <p>Om den döde har <em>både</em> gemensamma barn och särkullbarn gäller:</p>
+      <ul>
+        <li>Kvarlåtenskapen delas i lika delar mellan alla bröstarvingar.</li>
+        <li>Särkullbarnen kan kräva sin andel direkt.</li>
+        <li>De gemensamma barnens andel stannar hos den efterlevande maken med fri förfoganderätt.</li>
+        <li>Den efterlevande maken ärver alltså en del (de gemensamma barnens del) men inte särkullbarnens del.</li>
+      </ul>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Kan jag förhindra att mitt särkullbarn ärver?</h3>
+      <p>Nej. Särkullbarnet har alltid rätt till sin laglott — hälften av den arvslott de normalt fått. Du kan testamentera bort den andra hälften av deras arvslott, men laglotten kan inte tas ifrån dem oavsett omständigheterna. Det enda undantaget är om du kan bevisa att barnet har gjort sig skyldigt till grovt brott mot dig — vilket är ytterst sällsynt.</p>
+
+      <h3>Gäller samma regler för sambor med särkullbarn?</h3>
+      <p>Ja, särkullbarnens arvsrätt gäller oavsett om föräldern var gift eller sambo. Sambor har dessutom ett sämre grundskydd — en efterlevande sambo ärver ingenting utan testamente. Har man särkullbarn och är sambo är testamentesplanering extra viktig.</p>
+
+      <h3>Vad händer med huset om särkullbarnet kräver ut sin del?</h3>
+      <p>Om kvarlåtenskapen är bunden i en fastighet kan den efterlevande maken behöva lösa ut särkullbarnets andel i kontanter — eller sälja fastigheten. Det är just denna situation som kan tvinga en make att lämna familjehemmet. En livförsäkring kan ge den nödvändiga likviditeten för att lösa ut särkullbarnet utan att sälja.</p>
+
+      <div class="seo-cta">
+        <p>Hantera arvsskiftet strukturerat — checklista för bouppteckning och alla steg</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
+      <a href="./sambo-arv.html">Sambo och arv</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://efterplan.se/</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-04-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -56,6 +56,54 @@
   </url>
   <url>
     <loc>https://efterplan.se/arvsskatt.html</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/sambo-arv.html</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/tomma-dodsbo.html</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/sarkullbarn.html</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/salja-dodsbo.html</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/dodsbo-skulder.html</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/dodsbo-deklaration.html</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/fullmakt-dodsbo.html</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/bankkonto-dodsfall.html</loc>
     <lastmod>2026-04-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/testamente-guide.html
+++ b/testamente-guide.html
@@ -148,14 +148,14 @@
   <footer class="seo-footer">
     <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
     <p class="seo-footer-links">
+      <a href="./sambo-arv.html">Sambo och arv</a> &nbsp;·&nbsp;
+      <a href="./sarkullbarn.html">Särkullbarn</a> &nbsp;·&nbsp;
       <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
-      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
       <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
       <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
-      <a href="./dodsbo-bostadsratt.html">Dödsbo bostadsrätt</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
       <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
-      <a href="./efterlevandepension.html">Efterlevandepension</a> &nbsp;·&nbsp;
-      <a href="./vad-kostar-en-begravning.html">Vad kostar en begravning?</a>
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
     </p>
   </footer>
 </body>

--- a/tomma-dodsbo.html
+++ b/tomma-dodsbo.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tömma dödsbo — steg för steg, kostnader och tips 2026 | Efterplan</title>
+  <meta name="description" content="Hur tömmer man ett dödsbo? Vem ansvarar, vad kostar det och vad händer med saker ingen vill ha? Komplett guide 2026 med praktiska råd.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/tomma-dodsbo.html">
+  <meta property="og:title" content="Tömma dödsbo — steg för steg guide 2026">
+  <meta property="og:description" content="Allt om att tömma ett dödsbo: vem ansvarar, vad kostar det, vad gör man med sakerna och hur undviker man vanliga misstag.">
+  <meta property="og:url" content="https://efterplan.se/tomma-dodsbo.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Tömma dödsbo — steg för steg, kostnader och tips 2026",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-15",
+    "dateModified": "2026-04-15",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/tomma-dodsbo.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Vad kostar det att tömma ett dödsbo?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Kostnaden varierar kraftigt beroende på bostadens storlek och mängden bohag. En professionell dödsboröjning kostar vanligtvis 5 000–25 000 kr för en lägenhet och 15 000–50 000 kr för ett hus. Många firmor erbjuder värdering och köper värdefulla saker, vilket kan reducera eller eliminera kostnaden." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vem ansvarar för att tömma dödsboet?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Dödsbodelägarna ansvarar gemensamt för dödsboets förvaltning, inklusive att tömma bostaden. Om det finns en testamentsexekutor är det den personens ansvar. Alla dödsbodelägare måste vara överens om beslut som rör dödsboets egendom." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad gör man med saker som ingen arvinge vill ha?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Saker ingen arvinge vill ha kan skänkas till välgörenhet (Röda Korset, Myrorna, Erikshjälpen), säljas via dödsboauktion, lämnas till Stadsmissionen eller liknande, eller slängas. Kontakta kommunens återvinningscentral för hämtning av skrymmande föremål." }
+      },
+      {
+        "@type": "Question",
+        "name": "Måste man tömma dödsboet innan bouppteckning?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Nej. Bouppteckningen ska göras inom tre månader från dödsfallet och syftar till att förteckna tillgångar och skulder — inte att tömma bostaden. Det är rekommenderat att vänta med tömning tills bouppteckning och arvskifte är klart, så att värdefulla föremål inte försvinner innan arvingarna kommit överens." }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Tömma dödsbo — steg för steg guide 2026</h1>
+
+      <p>Att tömma ett dödsbo är ofta ett av de tyngsta praktiska stegen i sorgearbetet — en blandning av sorg, nostalgi och praktiska beslut om vad som ska hända med ett helt livs ägodelar. Den här guiden ger dig en tydlig struktur: vem som ansvarar, i vilken ordning du gör det, vad saker kan säljas eller skänkas för, och vad en professionell dödsboröjning kostar.</p>
+
+      <h2>Börja här — innan du tömmer något</h2>
+      <p>Locket på att tömma dödsboet för tidigt kan skapa juridiska problem och familjekonfliker. Gör dessa saker <strong>innan</strong> du börjar flytta eller kasta föremål:</p>
+      <ol>
+        <li><strong>Kontrollera om det finns testamente.</strong> Testamentet kan ange hur specifika föremål ska fördelas. Läs igenom det noga.</li>
+        <li><strong>Informera alla dödsbodelägare.</strong> Alla med del i dödsboet — barn, sambo, samägare — måste vara informerade och ha möjlighet att ta del av processen.</li>
+        <li><strong>Fotografera hemmet.</strong> Dokumentera med bilder innan ni börjar. Det skapar ett kvitto om frågor uppstår om vad som funnits i bostaden.</li>
+        <li><strong>Inventera värdesaker.</strong> Kontanta pengar, smycken, konst, antikviteter och samlingar ska identifieras och värderas <em>innan</em> de hanteras. De ingår i bouppteckningen.</li>
+        <li><strong>Hämta värdepapper och viktiga dokument.</strong> Bankbok, aktiedepåer, försäkringsbrev, fastighetshandlingar och liknande bör tas om hand direkt.</li>
+      </ol>
+
+      <h2>Vem ansvarar för att tömma dödsboet?</h2>
+      <p>Dödsboet är en juridisk person som ägs gemensamt av samtliga <strong>dödsbodelägare</strong> — det vill säga arvingar och testamentstagare. Alla beslut om dödsboets egendom fattas gemensamt, vilket innebär att:</p>
+      <ul>
+        <li>Inga saker får tas, säljas eller kastas utan att alla dödsbodelägare är överens.</li>
+        <li>Om en person tar egendom ur dödsboet utan samtycke kan det betraktas som olovligt förfogande.</li>
+        <li>Om delägarna är oeniga kan en <strong>boutredningsman</strong> utses av tingsrätten för att förvalta och avveckla dödsboet.</li>
+      </ul>
+      <p>I praktiken utser dödsbodelägarna ofta en av sig att koordinera arbetet — den personen kallas ibland dödsboförvaltare, men har inget formellt juridiskt mandat utan agerar som ombud med de andras samtycke.</p>
+
+      <h2>Steg-för-steg: så tömmer du dödsboet</h2>
+
+      <h3>Steg 1 — Säkra bostaden</h3>
+      <p>Byt lås eller samla in alla nycklar om du är orolig för obehörig tillgång. Avbryt inga abonnemang (el, vatten, internet) förrän bostaden är tömd — det kan skapa problem.</p>
+
+      <h3>Steg 2 — Sortera i kategorier</h3>
+      <p>Gå igenom hemmet systematiskt, rum för rum. Sortera i högar:</p>
+      <ul>
+        <li><strong>Arvinge vill ha</strong> — märk med post-it vem som tar vad.</li>
+        <li><strong>Sälja</strong> — värdefulla föremål som ingen arvinge vill ha.</li>
+        <li><strong>Skänka</strong> — bruksskick men ej värdefullt.</li>
+        <li><strong>Kasta</strong> — slitet, trasigt, personliga papper som inte behövs.</li>
+      </ul>
+      <p>Gå igenom alla lådor, garderober och förvaringsutrymmen — också vinden, källaren och eventuell friggebod.</p>
+
+      <h3>Steg 3 — Värdera och sälja</h3>
+      <p>Föremål med potentiellt värde kan säljas på flera sätt:</p>
+      <ul>
+        <li><strong>Auktionshus</strong> (Bukowskis, Stockholms Auktionsverk, Auctionet) — passar smycken, konst, silver, antikviteter. Tar provision 15–25 %.</li>
+        <li><strong>Blocket / Facebook Marketplace</strong> — effektivt för möbler, elektronik, kläder.</li>
+        <li><strong>Dödsbouppköpare</strong> — firmor som köper hela dödsbon. Snabbt och enkelt, men priset är lägre än marknadsvärde.</li>
+        <li><strong>Loppmarknader och Tradera</strong> — bra för lösa saker av litet värde.</li>
+      </ul>
+      <p>Pengarna från försäljning tillhör dödsboet och fördelas vid arvskiftet — de ska inte gå direkt till den som sköter försäljningen.</p>
+
+      <h3>Steg 4 — Skänka det som är kvar</h3>
+      <p>Bruksskick föremål som ingen vill ha eller sälja kan skänkas:</p>
+      <ul>
+        <li>Röda Korsets och Rädda Barnens secondhandbutiker</li>
+        <li>Myrorna (Frälsningsarmén)</li>
+        <li>Erikshjälpen</li>
+        <li>Stadsmissionen i din stad</li>
+        <li>Lokala volontärnätverk på Facebook</li>
+      </ul>
+      <p>Många organisationer hämtar möbler och skrymmande föremål gratis om du ringer och boka tid.</p>
+
+      <h3>Steg 5 — Sopsortera och släng resten</h3>
+      <p>Det som inte kan säljas eller skänkas behöver sorteras och slängas. Kommunens återvinningscentraler tar emot de flesta sorters avfall. Kontakta kommunen om du behöver hämtning av skrymmande avfall från adressen.</p>
+
+      <h3>Steg 6 — Slutstäda</h3>
+      <p>När bostaden är tömd behöver den slutstädas. Om det är en hyresrätt är det ett krav för att undvika avdrag på depositionen. Hyr in ett städföretag eller gör det själv. Glöm inte balkongen, förrådet och eventuella externa utrymmen.</p>
+
+      <h2>Vad kostar en professionell dödsboröjning?</h2>
+      <p>Många väljer att anlita ett professionellt dödsboröjningsföretag. Det sparar tid och kraft — och kan faktiskt bli billigare om firman köper värdefulla föremål.</p>
+
+      <table style="width:100%; border-collapse:collapse; margin:1em 0;">
+        <thead>
+          <tr style="background:#f0f0f0;">
+            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Bostadens storlek</th>
+            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Ungefärlig kostnad</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style="padding:8px; border:1px solid #ddd;">Lägenhet 1–2 rum</td>
+            <td style="padding:8px; border:1px solid #ddd;">5 000–12 000 kr</td>
+          </tr>
+          <tr>
+            <td style="padding:8px; border:1px solid #ddd;">Lägenhet 3–4 rum</td>
+            <td style="padding:8px; border:1px solid #ddd;">10 000–20 000 kr</td>
+          </tr>
+          <tr>
+            <td style="padding:8px; border:1px solid #ddd;">Villa, litet</td>
+            <td style="padding:8px; border:1px solid #ddd;">15 000–30 000 kr</td>
+          </tr>
+          <tr>
+            <td style="padding:8px; border:1px solid #ddd;">Villa, stort / landtgård</td>
+            <td style="padding:8px; border:1px solid #ddd;">30 000–80 000 kr</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>Priserna kan sänkas avsevärt om dödsboet innehåller värdefulla saker — firman värderar och köper dem och räknar av från priset. Begär alltid minst tre offerter och kolla omdömen på Google och Reco.se.</p>
+
+      <h2>Hyresrätt — viktiga detaljer</h2>
+      <p>Om den avlidne bodde i en hyresrätt gäller speciella regler:</p>
+      <ul>
+        <li>Hyresavtalet avslutas antingen genom att dödsboet säger upp det, eller att en närstående övertar det (överlåtelse kräver hyresvärdens godkännande).</li>
+        <li>Hyran betalas av dödsboet tills avtalet är uppsagt och uppsägningstiden är löpt ut — vanligtvis tre månader.</li>
+        <li>Bostaden måste vara tömd och städad senast på utflyttningsdagen.</li>
+        <li>Kontakta hyresvärden tidigt för att diskutera tidplan och undvika extra kostnader.</li>
+      </ul>
+
+      <h2>Bostadsrätt och fastighet</h2>
+      <p>Om den döde ägde en bostadsrätt eller fastighet gäller andra regler. Bostadsrätten ingår i dödsboet och övergår till arvingarna vid arvskiftet. Tills arvskiftet är genomfört ansvarar dödsboet för månadsavgiften och driftkostnaderna. Läs mer om <a href="./dodsbo-bostadsratt.html">dödsbo och bostadsrätt</a> och om <a href="./salja-dodsbo.html">att sälja dödsboets fastighet</a>.</p>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Kan en arvinge ta föremål hem "för att hålla dem säkra" innan arvskiftet?</h3>
+      <p>Nej, det är inte tillåtet utan samtycke från övriga dödsbodelägare. Egendom som tas ur dödsboet utan samtycke ska redovisas och kan betraktas som förskott på arv eller i värsta fall olovligt förfogande. Vänta alltid tills alla är överens.</p>
+
+      <h3>Hur hanterar vi personliga handlingar och foton?</h3>
+      <p>Personliga brev, dagböcker och privata handlingar tillhör juridiskt dödsboet men har sällan ekonomiskt värde. Arvingarna kan komma överens om att dessa fördelas som minnessaker. Digitalisera foton om ni vill bevara dem — det är lättare än att dela upp ett album.</p>
+
+      <h3>Vad händer om det finns saker vi inte kan identifiera eller värdera?</h3>
+      <p>Anlita en auktionskonsulent eller antikhandlare för en professionell värdering. Många auktionshus erbjuder gratis värdering av potentiellt intressanta föremål. Underskatta inte äldre smycken, silver och konst — de kan ha ett värde som inte är uppenbart.</p>
+
+      <div class="seo-cta">
+        <p>Håll koll på alla steg i dödsboprocessen — bouppteckning, arvskifte och tömning</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./salja-dodsbo.html">Sälja dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-bostadsratt.html">Dödsbo bostadsrätt</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./vad-kostar-en-begravning.html">Vad kostar en begravning?</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/vad-gora-nar-nagon-dor.html
+++ b/vad-gora-nar-nagon-dor.html
@@ -173,11 +173,11 @@
     <p class="seo-footer-links">
       <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
       <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./bankkonto-dodsfall.html">Bankkonto vid dödsfall</a> &nbsp;·&nbsp;
+      <a href="./tomma-dodsbo.html">Tömma dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./fullmakt-dodsbo.html">Fullmakt dödsbo</a> &nbsp;·&nbsp;
       <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
-      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
-      <a href="./dodsbo-bostadsratt.html">Dödsbo bostadsrätt</a> &nbsp;·&nbsp;
-      <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
-      <a href="./efterlevandepension.html">Efterlevandepension</a> &nbsp;·&nbsp;
       <a href="./vad-kostar-en-begravning.html">Vad kostar en begravning?</a>
     </p>
   </footer>

--- a/vad-kostar-en-begravning.html
+++ b/vad-kostar-en-begravning.html
@@ -154,11 +154,11 @@
       <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
       <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
       <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./tomma-dodsbo.html">Tömma dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./efterlevandepension.html">Efterlevandepension</a> &nbsp;·&nbsp;
       <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
-      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
-      <a href="./dodsbo-bostadsratt.html">Dödsbo bostadsrätt</a> &nbsp;·&nbsp;
-      <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
-      <a href="./efterlevandepension.html">Efterlevandepension</a>
+      <a href="./arvsskatt.html">Arvsskatt Sverige</a>
     </p>
   </footer>
 </body>


### PR DESCRIPTION
## Vad ingår

**8 nya SEO-sidor** (~26 000 extra sök/mån när indexerade):

| Sida | Primärt sökord | Est. sök/mån |
|------|---------------|-------------|
| sambo-arv.html | sambo arv | 4 000 |
| tomma-dodsbo.html | tömma dödsbo | 6 000 |
| sarkullbarn.html | särkullbarn | 2 500 |
| salja-dodsbo.html | sälja dödsbo | 3 500 |
| dodsbo-skulder.html | dödsbo skulder | 2 000 |
| dodsbo-deklaration.html | deklarera dödsbo | 2 000 |
| fullmakt-dodsbo.html | fullmakt dödsfall | 1 500 |
| bankkonto-dodsfall.html | bankkonto dödsfall | 2 500 |

**Övrigt:**
- `sitemap.xml` utökad till 18 URLs
- Footers på alla 10 befintliga sidor uppdaterade med korslenkar
- `ROADMAP.md` skapad med statusöversikt och prioriteringsmatris

**Totalt på sajten efter merge:** 18 SEO-sidor, ~50 000 sök/mån i estimerad organisk räckvidd.