### PR TITLE
T088: Frontend-uppgradering — editorial design polish (non-generic)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -158,6 +158,8 @@ Each step improves the product or the company in a meaningful way.
 
 | T059 | A11y pass: aria, focus, contrast | Fas 4.5 | UX Audit | 🟠 | A11y | ✔ |
 
+| T088 | Frontend-uppgradering (design polish, non-generic) | Fas 4.5 | Design Audit | 🟠 | Design | ✔ |
+
 
 
 \---

--- a/bouppteckning-guide.html
+++ b/bouppteckning-guide.html
@@ -12,6 +12,12 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" as="style"
+        href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
   <link rel="stylesheet" href="style.css">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>

--- a/checklista-dodsbo.html
+++ b/checklista-dodsbo.html
@@ -12,6 +12,12 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" as="style"
+        href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
   <link rel="stylesheet" href="style.css">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>

--- a/dodsbo-checklista-7-dagar.html
+++ b/dodsbo-checklista-7-dagar.html
@@ -12,6 +12,12 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" as="style"
+        href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
   <link rel="stylesheet" href="style.css">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
 
   <!-- PWA -->
   <link rel="manifest" href="manifest.json" />
-  <meta name="theme-color" content="#2C4A6E" />
+  <meta name="theme-color" content="#1F3A4E" />
   <link rel="icon" href="icon.svg" type="image/svg+xml" />
   <link rel="icon" type="image/png" href="favicon.png" />
 
@@ -107,9 +107,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link rel="preload" as="style"
-        href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'" />
-  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap" /></noscript>
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap" /></noscript>
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">
   {
@@ -144,11 +144,11 @@
     <div class="landing-content">
       <p class="landing-brand">Efterplan</p>
       <h1 class="landing-eyebrow">Du har precis förlorat någon.</h1>
-      <h2 class="landing-headline">Vi visar exakt vad du behöver göra — ett steg i taget.</h2>
+      <h2 class="landing-headline">Vi visar <em>exakt</em> vad du behöver göra — ett steg i taget.</h2>
       <ul class="landing-payoff">
-        <li>✓ Tar 2 minuter att starta</li>
-        <li>✓ Gratis, ingen registrering</li>
-        <li>✓ Rätt ordning — vi bestämmer åt dig</li>
+        <li>Tar 2 minuter att starta</li>
+        <li>Gratis, ingen registrering</li>
+        <li>Rätt ordning — vi bestämmer åt dig</li>
       </ul>
       <button class="btn-primary btn-large" onclick="startOnboarding()">Kom igång — tar 2 minuter</button>
       <p class="landing-note">Gratis att börja. Ingen registrering krävs.</p>

--- a/style.css
+++ b/style.css
@@ -1,35 +1,85 @@
 /* ═══════════════════════════════════════════
    EFTERPLAN — Stylesheet
-   Tone: Calm, trustworthy, minimal
+   Tone: Warm, trustworthy, clear — Swedish editorial
+   T088: Frontend-uppgradering (design polish, non-generic)
 ════════════════════════════════════════════ */
 
 
 :root {
-  --bg:           #F8F7F5;
-  --bg-card:      #FFFFFF;
-  --text-primary: #1C2333;
-  --text-soft:    #5A6A7E;
-  --text-muted:   #718096;  /* darkened from #94A3B8 — passes WCAG AA on white */
-  --text-secondary: #5A6A7E;
-  --border:       #E2E8F0;
-  --accent:       #2C4A6E;
-  --accent-dark:  #1a2f48;  /* hover state */
-  --accent-light: #EDF2F7;
-  --disabled-bg:  #D1D5DB;  /* disabled button */
-  --red:          #B91C1C;
-  --red-bg:       #FEF2F2;
-  --yellow:       #92400E;
-  --yellow-bg:    #FFFBEB;
-  --grey:         #718096;
-  --grey-bg:      #F1F5F9;
-  --green:         #3a7d5a;  /* ob-check-note, success */
-  --danger:        #c0392b;  /* notify remove hover */
-  --radius:       12px;
-  --radius-sm:    8px;
-  --shadow:       0 2px 12px rgba(44,74,110,0.08);
+  /* ── Paper & ink (warm, oklch-derived) ── */
+  --paper:        #F6F1E7;  /* warm off-white, like uncoated book stock */
+  --paper-soft:   #EFE8D8;  /* slightly deeper tone for section backs */
+  --paper-card:   #FBF7EE;  /* softest card surface, not pure white */
+  --ink:          #14192B;  /* deep warm ink — not pure black */
+  --ink-soft:     #394156;  /* body-emphasis / sub */
+  --ink-muted:    #485063;  /* meta, captions — 7.17:1 on paper, passes AAA */
+  --rule:         #E3DCCB;  /* warm border, tinted toward paper */
+  --rule-strong:  #CFC6B1;
+
+  /* ── Primary accent: deep ink-teal (trustworthy, pålitlig) ── */
+  --ink-teal:     #1F3A4E;
+  --ink-teal-dk:  #142739;
+  --ink-teal-tn:  #E7EEF2;  /* tinted surface, 8% */
+
+  /* ── Secondary accent: burnished terracotta (warm, human) ── */
+  --ember:        #B4552E;
+  --ember-dk:     #8E3F1E;
+  --ember-tn:     #F5E7DE;
+
+  /* ── Legacy mappings (do not remove — used throughout app) ── */
+  --bg:           var(--paper);
+  --bg-card:      var(--paper-card);
+  --text-primary: var(--ink);
+  --text-soft:    var(--ink-soft);
+  --text-muted:   var(--ink-muted);
+  --text-secondary: var(--ink-soft);
+  --border:       var(--rule);
+  --accent:       var(--ink-teal);
+  --accent-dark:  var(--ink-teal-dk);
+  --accent-light: var(--ink-teal-tn);
+  --disabled-bg:  #D6CEBC;
+  --red:          #9E3025;
+  --red-bg:       #F7E5DF;
+  --yellow:       #7A4A0F;
+  --yellow-bg:    #F6EBD1;
+  --grey:         var(--ink-muted);
+  --grey-bg:      #EFE8D8;
+  --green:        #2E6A48;
+  --danger:       #A23423;
+
+  --radius:       10px;
+  --radius-sm:    6px;
+  --radius-lg:    18px;
+  --shadow:       0 1px 2px rgba(20,25,43,.04), 0 8px 24px -12px rgba(20,25,43,.10);
+  --shadow-sm:    0 1px 2px rgba(20,25,43,.05);
   --transition:   0.2s ease;
-  --font:         'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
-  --nav-height:   57px;
+
+  /* ── Typography: distinctive display + humanist body ── */
+  --font-display: 'Fraunces', 'Iowan Old Style', 'Apple Garamond', Georgia, serif;
+  --font:         'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono:    'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  /* ── Fluid type scale (mobile → desktop) ── */
+  --fs-xs:    clamp(0.75rem, 0.73rem + 0.08vw, 0.8rem);
+  --fs-sm:    clamp(0.875rem, 0.85rem + 0.12vw, 0.95rem);
+  --fs-base:  clamp(1rem, 0.97rem + 0.15vw, 1.08rem);
+  --fs-md:    clamp(1.1rem, 1.05rem + 0.25vw, 1.22rem);
+  --fs-lg:    clamp(1.25rem, 1.17rem + 0.4vw, 1.5rem);
+  --fs-xl:    clamp(1.5rem, 1.35rem + 0.75vw, 2rem);
+  --fs-2xl:   clamp(1.95rem, 1.6rem + 1.6vw, 2.85rem);
+  --fs-3xl:   clamp(2.4rem, 1.9rem + 2.5vw, 4rem);
+
+  /* ── Fluid spacing (8-based, breathing on larger screens) ── */
+  --space-2xs: clamp(0.25rem, 0.22rem + 0.12vw, 0.35rem);
+  --space-xs:  clamp(0.5rem,  0.45rem + 0.2vw,  0.7rem);
+  --space-sm:  clamp(0.75rem, 0.65rem + 0.4vw,  1.05rem);
+  --space-md:  clamp(1.1rem,  0.95rem + 0.6vw,  1.6rem);
+  --space-lg:  clamp(1.75rem, 1.4rem + 1.3vw,   2.75rem);
+  --space-xl:  clamp(2.75rem, 2.1rem + 2.4vw,   4.5rem);
+  --space-2xl: clamp(4rem,    3rem + 3.6vw,     7rem);
+
+  --measure:   62ch;     /* optimal reading width */
+  --nav-height: 57px;
   --bottom-nav-height: 58px;
 }
 
@@ -61,10 +111,26 @@
 
 body {
   font-family: var(--font);
-  background: var(--bg);
-  color: var(--text-primary);
-  line-height: 1.6;
+  font-feature-settings: 'ss01', 'ss03', 'cv11';
+  /* Warm paper base with two very soft radial tints — depth without noise.
+     Painted on body background so stacking of sticky/fixed children is untouched. */
+  background-color: var(--paper);
+  background-image:
+    radial-gradient(1200px 800px at 85% -10%, rgba(180,85,46,.035), transparent 60%),
+    radial-gradient(900px 700px at -5% 110%, rgba(31,58,78,.045), transparent 55%);
+  background-attachment: fixed;
+  color: var(--ink);
+  line-height: 1.55;
   min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/* Selection echoes the ember accent */
+::selection {
+  background: var(--ember);
+  color: var(--paper);
 }
 
 /* ─── SCREENS ──────────────────────────────── */
@@ -119,27 +185,40 @@ body {
 
 /* ─── BUTTONS ────────────────────────────────── */
 .btn-primary {
-  background: var(--accent);
-  color: #fff;
+  background: var(--ink-teal);
+  color: var(--paper);
   border: none;
   border-radius: var(--radius-sm);
-  padding: 12px 24px;
-  font-size: 1rem;
-  font-weight: 600;
+  padding: 13px 22px;
+  font-family: var(--font);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  letter-spacing: 0.01em;
   cursor: pointer;
-  transition: var(--transition);
+  transition: background .18s ease, transform .18s ease, box-shadow .18s ease;
   width: 100%;
+  box-shadow: var(--shadow-sm);
 }
-.btn-primary:hover { background: var(--accent-dark); }
+.btn-primary:hover {
+  background: var(--ink-teal-dk);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+}
+.btn-primary:active { transform: translateY(0); }
 .btn-primary:disabled {
   background: var(--disabled-bg);
+  color: var(--ink-muted);
   cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 .btn-primary.btn-large {
-  padding: 16px 36px;
-  font-size: 1.1rem;
+  padding: 18px 34px;
+  font-size: var(--fs-base);
+  font-weight: 500;
+  letter-spacing: 0.005em;
   width: auto;
-  border-radius: 10px;
+  border-radius: 8px;
 }
 
 @keyframes ctaPulse {
@@ -250,98 +329,169 @@ body {
 }
 .landing-hero {
   min-height: calc(100vh - 80px);
-  display: flex;
+  display: grid;
   align-items: center;
-  justify-content: center;
-  padding: 40px 20px;
-  background: linear-gradient(160deg, #F8F7F5 0%, #EDF2F7 100%);
+  padding: var(--space-xl) var(--space-md) var(--space-lg);
+  background: transparent;
+  position: relative;
+}
+/* Editorial ornament — asymmetric rule, purposeful (not decorative filler) */
+.landing-hero::after {
+  content: '';
+  position: absolute;
+  left: var(--space-md);
+  bottom: var(--space-lg);
+  width: clamp(36px, 6vw, 64px);
+  height: 1px;
+  background: var(--ember);
+  opacity: .7;
 }
 .landing-content {
-  max-width: 620px;
-  text-align: center;
+  max-width: 640px;
+  margin: 0;
+  text-align: left;
+  padding-left: clamp(0px, 4vw, 32px);
 }
 .landing-brand {
-  font-size: 1.45rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  letter-spacing: -0.02em;
-  margin-bottom: 6px;
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 14, 'SOFT' 50, 'wght' 500;
+  font-size: var(--fs-md);
+  font-weight: 500;
+  font-style: italic;
+  color: var(--ink-soft);
+  letter-spacing: 0;
+  margin-bottom: var(--space-md);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+.landing-brand::before {
+  content: '';
+  width: 18px;
+  height: 1px;
+  background: var(--ember);
 }
 
 .landing-eyebrow {
-  font-size: 0.9rem;
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
-  color: var(--accent);
-  font-weight: 600;
-  margin-bottom: 16px;
-  /* h1 reset — behåller eyebrow-utseendet oavsett tagg */
-  line-height: 1.2;
+  font-family: var(--font);
+  font-size: var(--fs-sm);
+  letter-spacing: 0.02em;
+  color: var(--ink-soft);
+  font-weight: 500;
+  margin-bottom: var(--space-sm);
+  line-height: 1.4;
   padding: 0;
+  text-transform: none;
 }
 .landing-headline {
-  font-size: clamp(1.35rem, 3.5vw, 1.9rem);
-  font-weight: 700;
-  line-height: 1.2;
-  color: var(--text-primary);
-  margin-bottom: 20px;
-  letter-spacing: -0.5px;
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 144, 'SOFT' 40, 'wght' 420;
+  font-size: var(--fs-3xl);
+  font-weight: 420;
+  line-height: 1.02;
+  color: var(--ink);
+  margin-bottom: var(--space-md);
+  letter-spacing: -0.025em;
+  max-width: 14ch;
+}
+.landing-headline em {
+  font-style: italic;
+  font-variation-settings: 'opsz' 144, 'SOFT' 90, 'wght' 420;
+  color: var(--ink-teal);
 }
 .landing-sub {
-  font-size: 1.1rem;
-  color: var(--text-soft);
-  max-width: 480px;
-  margin: 0 auto 36px;
-  line-height: 1.7;
+  font-size: var(--fs-md);
+  color: var(--ink-soft);
+  max-width: 46ch;
+  margin: 0 0 var(--space-lg);
+  line-height: 1.6;
 }
 .landing-payoff {
   list-style: none;
   padding: 0;
-  margin: 0 auto 28px;
-  max-width: 380px;
+  margin: 0 0 var(--space-md);
+  max-width: 42ch;
   text-align: left;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-xs);
+  border-top: 1px solid var(--rule);
+  padding-top: var(--space-md);
 }
 .landing-payoff li {
-  font-size: 0.9rem;
-  color: var(--text-soft);
-  padding-left: 20px;
+  font-size: var(--fs-sm);
+  color: var(--ink-soft);
+  padding-left: 26px;
   position: relative;
+  line-height: 1.5;
 }
 .landing-payoff li::before {
-  content: '✓';
+  content: '';
   position: absolute;
   left: 0;
-  color: var(--accent);
-  font-weight: 700;
+  top: 0.55em;
+  width: 14px;
+  height: 1px;
+  background: var(--ink-teal);
 }
 .landing-note {
-  margin-top: 14px;
-  font-size: 0.85rem;
-  color: var(--text-muted);
+  margin-top: var(--space-sm);
+  font-size: var(--fs-xs);
+  color: var(--ink-muted);
+  letter-spacing: 0.01em;
 }
 
-/* ─── LANDING SECTIONS (Om / Integritet) ────── */
+/* Nudge brand logo in nav into the editorial voice */
+#screen-landing .logo {
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 36, 'SOFT' 40, 'wght' 500;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+
+@media (min-width: 720px) {
+  .landing-hero {
+    grid-template-columns: minmax(0, 1fr);
+    padding: var(--space-2xl) clamp(2rem, 6vw, 5rem);
+  }
+  .landing-content { padding-left: 0; }
+  .landing-headline { max-width: 16ch; }
+}
+
+/* ─── LANDING SECTIONS (Om / Integritet / FAQ) ── */
 .landing-section {
-  max-width: 680px;
+  max-width: 720px;
   margin: 0 auto;
-  padding: 56px 20px;
-  border-top: 1px solid var(--border);
+  padding: var(--space-xl) var(--space-md);
+  border-top: 1px solid var(--rule);
+  position: relative;
+}
+.landing-section::before {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: var(--space-md);
+  width: 40px;
+  height: 1px;
+  background: var(--ember);
 }
 .landing-section h2 {
-  font-size: 1.4rem;
-  font-weight: 700;
-  letter-spacing: -0.3px;
-  margin-bottom: 14px;
-  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 60, 'SOFT' 40, 'wght' 500;
+  font-size: var(--fs-xl);
+  font-weight: 500;
+  letter-spacing: -0.018em;
+  line-height: 1.15;
+  margin-bottom: var(--space-md);
+  color: var(--ink);
 }
 .landing-section p {
-  font-size: 0.95rem;
-  color: var(--text-soft);
+  font-size: var(--fs-base);
+  color: var(--ink-soft);
   line-height: 1.75;
-  margin-bottom: 10px;
+  margin-bottom: var(--space-sm);
+  max-width: var(--measure);
 }
 .landing-section p:last-child { margin-bottom: 0; }
 .landing-contact-link {
@@ -361,9 +511,9 @@ body {
   line-height: 1.6;
 }
 .faq-item {
-  margin-bottom: 28px;
-  padding-bottom: 28px;
-  border-bottom: 1px solid var(--border);
+  margin-bottom: var(--space-md);
+  padding-bottom: var(--space-md);
+  border-bottom: 1px solid var(--rule);
 }
 .faq-item:last-child {
   margin-bottom: 0;
@@ -371,17 +521,34 @@ body {
   border-bottom: none;
 }
 .faq-item h3 {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: 8px;
-  line-height: 1.4;
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 36, 'SOFT' 40, 'wght' 500;
+  font-size: var(--fs-md);
+  font-weight: 500;
+  color: var(--ink);
+  margin-bottom: var(--space-xs);
+  line-height: 1.3;
+  letter-spacing: -0.012em;
 }
 .faq-item p {
-  font-size: 0.92rem;
-  color: var(--text-soft);
+  font-size: var(--fs-base);
+  color: var(--ink-soft);
   line-height: 1.75;
   margin: 0;
+  max-width: var(--measure);
+}
+.faq-item p a,
+.landing-section p a {
+  color: var(--ink-teal);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  text-decoration-color: color-mix(in oklab, var(--ink-teal) 40%, transparent);
+  transition: text-decoration-color .15s ease;
+}
+.faq-item p a:hover,
+.landing-section p a:hover {
+  text-decoration-color: var(--ember);
 }
 .privacy-badges {
   display: flex;
@@ -404,17 +571,24 @@ body {
 
 /* ─── LANDING FOOTER ─────────────────────────── */
 .landing-footer {
-  background: var(--text-primary);
-  color: rgba(255,255,255,0.5);
-  padding: 20px;
+  background: var(--ink);
+  color: color-mix(in oklab, var(--paper) 55%, transparent);
+  padding: var(--space-md) var(--space-md) calc(var(--space-md) + env(safe-area-inset-bottom, 0px));
   text-align: center;
-  font-size: 0.8rem;
+  font-size: var(--fs-xs);
+  letter-spacing: 0.01em;
+  font-family: var(--font);
 }
 .landing-footer a {
-  color: rgba(255,255,255,0.75);
+  color: color-mix(in oklab, var(--paper) 82%, transparent);
   text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color .15s ease, color .15s ease;
 }
-.landing-footer a:hover { color: #fff; text-decoration: underline; }
+.landing-footer a:hover {
+  color: var(--paper);
+  border-bottom-color: var(--ember);
+}
 
 /* ─── ONBOARDING (fullscreen conversational) ─── */
 #screen-onboarding {
@@ -2445,18 +2619,253 @@ body {
   white-space: nowrap;
 }
 
-/* ═══ SEO PAGES (T061) ════════════════════════ */
-.seo-nav { display: flex; justify-content: space-between; align-items: center; padding: 16px 24px; border-bottom: 1px solid var(--border); }
-.seo-main { max-width: 680px; margin: 0 auto; padding: 40px 24px; }
-.seo-article h1 { font-size: 1.8rem; margin-bottom: 24px; line-height: 1.25; }
-.seo-article h2 { font-size: 1.15rem; font-weight: 700; margin: 32px 0 12px; }
-.seo-article p { line-height: 1.75; color: var(--text-primary); margin-bottom: 16px; }
-.seo-article ul { padding-left: 20px; margin-bottom: 16px; }
-.seo-article li { line-height: 1.7; margin-bottom: 6px; }
-.seo-cta { background: var(--accent-light, #f0f4f8); padding: 24px; border-radius: var(--radius); text-align: center; margin: 40px 0; }
-.seo-cta p { margin-bottom: 12px; font-weight: 600; }
-.seo-footer { text-align: center; padding: 24px; color: var(--text-soft); font-size: 0.85rem; border-top: 1px solid var(--border); margin-top: 40px; }
-.seo-footer-links { font-size: 0.8rem; margin-top: 6px; opacity: 0.8; }
-.seo-footer-links a { color: inherit; }
+/* ═══ SEO PAGES (T061, uppdaterad T088) ═════════ */
+.seo-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: saturate(1.1);
+}
+.seo-nav .logo-text {
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 36, 'SOFT' 40, 'wght' 500;
+  font-size: var(--fs-md);
+  font-weight: 500;
+  color: var(--ink);
+  letter-spacing: -0.02em;
+}
+.seo-nav .btn-primary {
+  width: auto;
+  padding: 9px 18px;
+  font-size: var(--fs-xs);
+}
+
+.seo-main {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: var(--space-xl) var(--space-md) var(--space-lg);
+}
+.seo-article { counter-reset: h2counter; }
+
+.seo-article h1 {
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 144, 'SOFT' 50, 'wght' 420;
+  font-size: var(--fs-3xl);
+  font-weight: 420;
+  line-height: 1.02;
+  letter-spacing: -0.028em;
+  margin: 0 0 var(--space-md);
+  color: var(--ink);
+  max-width: 18ch;
+  text-wrap: balance;
+}
+
+/* Lead paragraph — first p after h1 gets editorial lead treatment */
+.seo-article h1 + p {
+  font-size: var(--fs-md);
+  color: var(--ink-soft);
+  line-height: 1.6;
+  max-width: var(--measure);
+  margin-bottom: var(--space-lg);
+  padding-bottom: var(--space-md);
+  border-bottom: 1px solid var(--rule);
+}
+
+.seo-article h2 {
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 48, 'SOFT' 40, 'wght' 500;
+  font-size: var(--fs-xl);
+  font-weight: 500;
+  line-height: 1.2;
+  letter-spacing: -0.018em;
+  color: var(--ink);
+  margin: var(--space-lg) 0 var(--space-sm);
+  max-width: 32ch;
+  counter-increment: h2counter;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: baseline;
+  gap: var(--space-sm);
+}
+.seo-article h2::before {
+  content: counter(h2counter, decimal-leading-zero);
+  font-family: var(--font);
+  font-weight: 500;
+  font-size: var(--fs-xs);
+  letter-spacing: 0.14em;
+  color: var(--ink-teal);
+  padding-top: 0.55em;
+  border-top: 1px solid var(--ember);
+  line-height: 1;
+  align-self: start;
+  min-width: 2.4em;
+}
+
+.seo-article h3 {
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 30, 'SOFT' 40, 'wght' 500;
+  font-size: var(--fs-lg);
+  font-weight: 500;
+  line-height: 1.25;
+  letter-spacing: -0.012em;
+  margin: var(--space-md) 0 var(--space-xs);
+  color: var(--ink);
+}
+
+.seo-article p {
+  line-height: 1.78;
+  color: var(--ink);
+  margin-bottom: var(--space-sm);
+  max-width: var(--measure);
+  font-size: var(--fs-base);
+}
+.seo-article p strong { color: var(--ink); font-weight: 600; }
+
+.seo-article a {
+  color: var(--ink-teal);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  text-decoration-color: color-mix(in oklab, var(--ink-teal) 35%, transparent);
+  transition: text-decoration-color .15s ease;
+}
+.seo-article a:hover { text-decoration-color: var(--ember); }
+
+.seo-article ul, .seo-article ol {
+  padding-left: 0;
+  list-style: none;
+  margin: 0 0 var(--space-md);
+  max-width: var(--measure);
+  counter-reset: listmarker;
+}
+.seo-article ul li, .seo-article ol li {
+  line-height: 1.72;
+  margin-bottom: var(--space-xs);
+  padding-left: 28px;
+  position: relative;
+  color: var(--ink);
+  font-size: var(--fs-base);
+}
+.seo-article ul li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.72em;
+  width: 14px;
+  height: 1px;
+  background: var(--ember);
+}
+.seo-article ol li {
+  counter-increment: listmarker;
+}
+.seo-article ol li::before {
+  content: counter(listmarker) '.';
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 14, 'wght' 500;
+  font-style: italic;
+  color: var(--ink-teal);
+  font-weight: 500;
+}
+
+.seo-article blockquote {
+  margin: var(--space-md) 0;
+  padding: var(--space-sm) 0 var(--space-sm) var(--space-md);
+  border-left: 2px solid var(--ember);
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 24, 'SOFT' 60, 'wght' 400;
+  font-style: italic;
+  font-size: var(--fs-md);
+  line-height: 1.55;
+  color: var(--ink-soft);
+  max-width: var(--measure);
+}
+
+/* Inline CTA box — editorial, not generic "card" */
+.seo-cta {
+  background: var(--paper-soft);
+  border: 1px solid var(--rule);
+  border-left: 2px solid var(--ink-teal);
+  padding: var(--space-md) var(--space-md) var(--space-md);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  text-align: left;
+  margin: var(--space-lg) 0;
+  max-width: var(--measure);
+  box-shadow: none;
+}
+.seo-cta p {
+  margin-bottom: var(--space-sm);
+  font-weight: 400;
+  font-family: var(--font-display);
+  font-variation-settings: 'opsz' 20, 'SOFT' 50, 'wght' 500;
+  font-size: var(--fs-md);
+  color: var(--ink);
+  font-style: italic;
+  max-width: 40ch;
+}
+.seo-cta .btn-primary {
+  width: auto;
+  padding: 12px 22px;
+}
+
+.seo-footer {
+  text-align: left;
+  padding: var(--space-lg) var(--space-md);
+  color: var(--ink-muted);
+  font-size: var(--fs-xs);
+  border-top: 1px solid var(--rule);
+  margin-top: var(--space-xl);
+  max-width: 760px;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.7;
+}
+.seo-footer-links {
+  font-size: var(--fs-xs);
+  margin-top: var(--space-xs);
+}
+.seo-footer-links a {
+  color: var(--ink-muted);
+  text-decoration: underline;
+  text-decoration-color: var(--rule);
+  text-underline-offset: 3px;
+}
+.seo-footer-links a:hover {
+  color: var(--ink-teal);
+  text-decoration-color: var(--ember);
+}
+.landing-footer-links {
+  font-size: var(--fs-xs);
+  margin-top: var(--space-xs);
+  opacity: 0.9;
+}
+.landing-footer-links a { color: inherit; }
+
+/* ─── FOCUS: AAA visibility on both paper and dark surfaces ── */
+:focus-visible {
+  outline: 2px solid var(--ember);
+  outline-offset: 3px;
+  border-radius: 3px;
+  transition: none;
+}
+
+/* ─── REDUCED MOTION ─────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+  .btn-primary:hover { transform: none; }
+}
 .landing-footer-links { font-size: 0.8rem; margin-top: 6px; opacity: 0.7; }
 .landing-footer-links a { color: inherit; }

--- a/tomma-dodsbo.html
+++ b/tomma-dodsbo.html
@@ -12,6 +12,12 @@
   <meta property="og:url" content="https://efterplan.se/tomma-dodsbo.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" as="style"
+        href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
   <link rel="stylesheet" href="style.css">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>


### PR DESCRIPTION
## Summary

Rebrand av `index.html` + de 4 mest trafikerade SEO-sidorna (checklista-dodsbo, bouppteckning-guide, tomma-dodsbo, dodsbo-checklista-7-dagar) från generisk AI-look till en distinkt **Swedish Editorial**-känsla som matchar Manifest-tonen (varm, hjälpsam, tydlig, pålitlig).

### Designriktning
- **Typografi**: `Fraunces` (variable serif med SOFT- och opsz-axlar) för display, `IBM Plex Sans` för brödtext. Ersätter `DM Sans`.
- **Palett**: "warm paper" `#F6F1E7` + deep ink `#14192B` + ink-teal primär `#1F3A4E` + burnished terracotta `#B4552E`. Djup via två mycket subtila radial-tinter (~3–4 % opacity) — inga dekorativa gradienter, inga stock-bilder.
- **Hero**: vänsterställd asymmetrisk komposition, Fraunces-headline med kursivt `<em>exakt</em>`, liten ember-rule som editorial ornament. `landing-payoff` byter `✓`-checkmarks mot tunn horisontell rule för tystare visuell rytm.
- **SEO-artiklar**: decimal-leading-zero-nummer på H2 (`01 →`, `02 →`…), lead-paragraf efter H1, kursiv Fraunces-blockquote, horisontell 1px-rule som list-marker. Mät-bredd låst till `62ch`.

### Tekniska krav (uppfyllda)
- ✅ Fortsatt **single-file `style.css`** (ingen build-pipeline)
- ✅ **Inga nya JS-dependencies** — endast CSS + Google Fonts (variable + latin-subset)
- ✅ **Designtokens**: fluid type scale via `clamp()`, fluid spacing, `--measure: 62ch`, radius + shadow-skala
- ✅ **Legacy-variabler** behållna (`--bg`, `--accent` etc mappas nu till nya tokens) → övriga sidor & onboarding fortsätter fungera utan regression
- ✅ **A11y**:
  - `--ink-muted` mörknad till `#485063` → **7.17:1 på paper** (AAA)
  - `ink` på paper: 15.50:1, `ink-soft`: 9.04:1, `ink-teal`-länkar: 10.52:1 — alla **AAA**
  - `@media (prefers-reduced-motion: reduce)` blockerar animationer
  - Focus-ring byter till ember för synlighet mot både ljus paper och mörk ink-teal
- ✅ **Performance**: `font-display: swap`, `preconnect` + `preload`, latin-subset, endast vikter 400–600. Ingen ändring av kritisk render-path — CSS byggd för att inte regressera PageSpeed mobil ≥90.

### Före → Efter (designförändringar)
| Del | Före | Efter |
|---|---|---|
| Display-font | DM Sans (generic sans) | Fraunces variable serif, opsz 9–144, SOFT 30–80 |
| Body-font | DM Sans | IBM Plex Sans (ss01/ss03) |
| Bakgrund | Solid `#F8F7F5` + blå hero-gradient | Warm paper `#F6F1E7` + dubbla radial-tinter (3–4 %) |
| Primär accent | `#2C4A6E` (slate blå) | Ink-teal `#1F3A4E` (djupare, lägre chroma) |
| Sekundär accent | — | Burnished terracotta `#B4552E` (varm, mänsklig) |
| Hero-layout | Centrerad, `<h1>`/`<h2>` stack | Vänsterställd asymmetrisk, serif-italic emphasis |
| SEO H2 | `1.15rem, weight 700, sans` | Fluid serif + `01 →`-nummer + ember-rule |
| Listor | `✓`-unicode + `•` | Tunn 1px-horisontalrule + Fraunces-italic siffror |
| Länkar | Underline solid | Underline `color-mix` 35 % opacity → ember på hover |

### Roadmap
Lägger till rad i Fas 4.5:
```
| T088 | Frontend-uppgradering (design polish, non-generic) | Fas 4.5 | Design Audit | 🟠 | Design | ✔ |
```

## Test plan
- [ ] Ladda `index.html` — verifiera Fraunces serif på hero, ember-rule längst ner vänster
- [ ] Ladda `checklista-dodsbo.html` — verifiera `01`/`02`-numrerade H2 med ember-top-rule
- [ ] Ladda `bouppteckning-guide.html`, `tomma-dodsbo.html`, `dodsbo-checklista-7-dagar.html` — samma behandling
- [ ] Kör Lighthouse mobile på index.html — Performance ≥90, A11y = 100
- [ ] Kör `prefers-reduced-motion: reduce` i DevTools → animationer ska stanna
- [ ] Tabba genom hero-CTA → ember-focus-ring synlig
- [ ] Testa på riktig iPhone / Android (smal viewport) — `landing-headline` wrappar korrekt, ingen horisontell scroll
- [ ] Övriga sidor (arvskifte-guide, arvsskatt, etc) ska fortfarande fungera — de ärver CSS-variabler och faller tillbaka till system-sans tills fonterna rullas ut sitesbrett i senare ticket
- [ ] Onboarding-flödet (`#screen-onboarding` → plan-vyn) ska se fräscht men oförändrat ut (endast palette-skift, inga layoutändringar)

https://claude.ai/code/session_01K9ToSKW3Db4FpCp2rRTzuD