### PR TITLE
T089–T091: tre nya SEO-sidor (dödsfallsintyg, laglott, hyresrätt dödsbo)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -429,4 +429,7 @@ Each step improves the product or the company in a meaningful way.
 
 | T083 | Weekly KPI review + new 14‑day plan | 2026‑05‑06 | Fas 11 | Growth | 🟡 | Growth | ✔ |
 | T087 | Länkbyggnad: identifiera 10 relevanta sajter för gästinlägg/omnämnanden (begravning, juridik, ekonomi) | 2026‑05‑10 | Fas 11 | SEO Audit | 🟠 | SEO | ☐ |
+| T089 | SEO-sida: dodsfallsintyg | Fas 11 | SEO Sprint | 🟡 | SEO | ✔ |
+| T090 | SEO-sida: laglott | Fas 11 | SEO Sprint | 🟡 | SEO | ✔ |
+| T091 | SEO-sida: saga-upp-hyresratt-dodsbo | Fas 11 | SEO Sprint | 🟡 | SEO | ✔ |
 

--- a/dodsfallsintyg.html
+++ b/dodsfallsintyg.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dödsfallsintyg 2026 — så beställer du det, vad det kostar och när du behöver det | Efterplan</title>
+  <meta name="description" content="Dödsfallsintyg: vad det är, hur du beställer från Skatteverket, skillnaden mot dödsbevis och släktutredning. Tidsramar, kostnad och praktiska exempel på när intyget behövs.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/dodsfallsintyg.html">
+  <meta property="og:title" content="Dödsfallsintyg — beställa, använda, tidsramar">
+  <meta property="og:description" content="Så beställer du dödsfallsintyg med eller utan släktutredning från Skatteverket. Komplett guide med tidsramar och exempel.">
+  <meta property="og:url" content="https://efterplan.se/dodsfallsintyg.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" as="style"
+        href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    @media print {
+      .seo-nav, .seo-cta, .seo-footer-links { display: none; }
+      .seo-main { max-width: 100%; padding: 0; }
+      .seo-article a { color: inherit; text-decoration: none; }
+      body { background: #fff; color: #000; }
+    }
+  </style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Dödsfallsintyg — så beställer du det, vad det kostar och när du behöver det",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-22",
+    "dateModified": "2026-04-22",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/dodsfallsintyg.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Vad är skillnaden på dödsbevis och dödsfallsintyg?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Dödsbeviset utfärdas automatiskt av läkaren som konstaterade dödsfallet och skickas direkt till Skatteverket — du behöver inte göra något. Dödsfallsintyget är det dokument som du själv beställer från Skatteverket och som banker, försäkringsbolag och andra aktörer kräver för att du ska kunna företräda dödsboet." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad kostar ett dödsfallsintyg?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Dödsfallsintyget är kostnadsfritt. Skatteverket tar inte ut någon avgift, oavsett om du beställer intyg med eller utan släktutredning, och oavsett hur många kopior du behöver." }
+      },
+      {
+        "@type": "Question",
+        "name": "Hur lång tid tar det att få ett dödsfallsintyg?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Dödsfallet registreras hos Skatteverket inom några arbetsdagar efter att läkaren skickat in dödsbeviset. När registreringen är klar kan du beställa dödsfallsintyget, och det når dig normalt inom 3–5 arbetsdagar. Intyg med släktutredning kan ta upp till två veckor." }
+      },
+      {
+        "@type": "Question",
+        "name": "Behöver jag dödsfallsintyg eller släktutredning?",
+        "acceptedAnswer": { "@type": "Answer", "text": "För att avsluta enstaka konton eller kontakta ett försäkringsbolag räcker oftast ett enkelt dödsfallsintyg. För att företräda dödsboet i bankärenden, vid bouppteckning eller när en fastighet ska säljas kräver motparten nästan alltid dödsfallsintyg med släktutredning — det visar vilka som är arvingar." }
+      },
+      {
+        "@type": "Question",
+        "name": "Kan jag beställa dödsfallsintyg digitalt?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja. Du loggar in på skatteverket.se med BankID och beställer dödsfallsintyget där. Du kan också ringa Skatteverket på 0771-567 567 eller besöka ett servicekontor." }
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Efterplan", "item": "https://efterplan.se/" },
+      { "@type": "ListItem", "position": 2, "name": "Dödsfallsintyg", "item": "https://efterplan.se/dodsfallsintyg.html" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Dödsfallsintyg — så beställer du det, vad det kostar och när du behöver det</h1>
+
+      <p>Ett dödsfallsintyg är det dokument som banker, försäkringsbolag och myndigheter kräver för att du ska få företräda dödsboet efter någon som gått bort. Det utfärdas kostnadsfritt av Skatteverket — men många förväxlar det med läkarens dödsbevis, eller är osäkra på om de behöver intyget med släktutredning eller inte. Den här guiden reder ut skillnaderna, visar exakt hur du beställer, och går igenom när i processen du behöver intyget.</p>
+
+      <h2>Vad är ett dödsfallsintyg?</h2>
+      <p>Dödsfallsintyget är ett officiellt bevis på att en person är avliden, utfärdat av Skatteverket ur folkbokföringen. Det innehåller den avlidnes namn, personnummer, dödsdatum och senaste folkbokföringsadress. När banken eller försäkringsbolaget ber om "intyg på dödsfallet" är det just det här dokumentet de menar — inte läkarens dödsbevis.</p>
+
+      <h3>Skillnaden mot dödsbeviset</h3>
+      <p>Dödsbeviset och dödsfallsintyget är två olika handlingar som skapas i olika delar av processen:</p>
+      <ul>
+        <li><strong>Dödsbeviset</strong> utfärdas av läkaren som konstaterade dödsfallet och skickas automatiskt till Skatteverket. Du som anhörig behöver inte beställa det eller göra något för att det ska utfärdas.</li>
+        <li><strong>Dödsfallsintyget</strong> är det du själv beställer från Skatteverket efter att dödsbeviset registrerats i folkbokföringen. Det är detta intyg som används i alla praktiska ärenden efter dödsfallet.</li>
+      </ul>
+      <p>Förväxlingen är vanlig och leder till onödiga förseningar. Banker tar aldrig emot dödsbeviset som bevis på dödsfall — de vill alltid ha dödsfallsintyget.</p>
+
+      <h2>Dödsfallsintyg med eller utan släktutredning?</h2>
+      <p>Skatteverket utfärdar två varianter av dödsfallsintyget. Valet påverkar både handläggningstid och vad intyget kan användas till.</p>
+
+      <h3>Enkelt dödsfallsintyg</h3>
+      <p>Den enkla varianten bekräftar bara att personen är avliden. Den räcker i avgränsade ärenden där mottagaren inte behöver veta vilka arvingar som finns — till exempel för att avsluta enstaka abonnemang, anmäla dödsfallet till arbetsgivaren eller pausa försäkringar.</p>
+
+      <h3>Dödsfallsintyg med släktutredning</h3>
+      <p>Släktutredningen listar alla dödsbodelägare: efterlevande make eller maka, barn (inklusive särkullbarn och adopterade barn), och i vissa fall andra arvingar enligt arvsordningen. Den här varianten krävs i praktiken för alla ärenden där någon måste företräda dödsboet gentemot en motpart — alltså i de flesta fall.</p>
+      <p>Du behöver intyget <strong>med släktutredning</strong> för att:</p>
+      <ul>
+        <li>Avsluta eller ta ut medel från den avlidnes bankkonton. <a href="./bankkonto-dodsfall.html">Läs mer om bankkonton vid dödsfall.</a></li>
+        <li>Genomföra <a href="./bouppteckning-guide.html">bouppteckning</a>.</li>
+        <li>Säga upp hyreskontrakt eller överlåta en hyresrätt.</li>
+        <li>Sälja bostadsrätt, fastighet eller bil som tillhört den avlidne.</li>
+        <li>Begära utbetalning från livförsäkringar där förmånstagare inte är förordnad.</li>
+        <li>Avregistrera fordon hos Transportstyrelsen.</li>
+      </ul>
+      <p>Tumregel: om du är osäker, beställ intyget med släktutredning. Det tar några dagar extra men täcker nästan alla behov. Beställer du fel variant får du vänta på en ny leverans.</p>
+
+      <h2>Så beställer du dödsfallsintyget — tre vägar</h2>
+      <p>Skatteverket erbjuder flera kanaler. Alla är kostnadsfria, och du kan beställa hur många kopior du behöver.</p>
+
+      <h3>Via skatteverket.se — snabbast</h3>
+      <ol>
+        <li>Logga in på <strong>skatteverket.se</strong> med BankID.</li>
+        <li>Välj "Folkbokföring" → "Dödsfallsintyg".</li>
+        <li>Ange den avlidnes personnummer och välj variant (med eller utan släktutredning).</li>
+        <li>Välj adress för leverans — posta hem, till annan adress eller till det digitala brevlådelösning (Kivra, Min myndighetspost) som du använder.</li>
+      </ol>
+      <p>Den digitala beställningen går snabbt. Om dödsbeviset redan är registrerat får du intyget på papper inom några arbetsdagar, eller direkt som PDF i din digitala brevlåda.</p>
+
+      <h3>Via telefon till Skatteverket</h3>
+      <p>Ring <strong>0771-567 567</strong> och be om dödsfallsintyg. Handläggaren identifierar dig och skickar intyget per post. Ha den avlidnes personnummer, ditt eget personnummer och en leveransadress till hands. Telefonbeställning passar dig som inte har BankID eller föredrar att prata med en person.</p>
+
+      <h3>Vid besök på servicekontor</h3>
+      <p>Skatteverkets servicekontor (finns i de flesta större städer) kan hjälpa dig beställa intyget på plats. Räkna med kö och ta med giltig legitimation. Det här alternativet passar när det är bråttom och du bor nära ett kontor — i vissa fall kan du få intyget utskrivet direkt.</p>
+
+      <h2>Tidsramar — när kan du få intyget?</h2>
+      <p>Dödsfallsintyget kan utfärdas först när dödsfallet är registrerat i folkbokföringen. Tidslinjen ser typiskt ut så här:</p>
+      <ul>
+        <li><strong>Dag 1:</strong> Läkaren utfärdar dödsbeviset och skickar det till Skatteverket (digitalt, oftast samma dag).</li>
+        <li><strong>Dag 2–5:</strong> Skatteverket registrerar dödsfallet i folkbokföringen. Efter det kan dödsfallsintyg beställas.</li>
+        <li><strong>Dag 3–7:</strong> Enkelt dödsfallsintyg levereras, oftast per post. Digital leverans via Kivra kan vara samma dag.</li>
+        <li><strong>Dag 5–14:</strong> Intyg med släktutredning levereras. Släktutredningen kräver lite mer handläggning eftersom Skatteverket ska slå fast arvingarna.</li>
+      </ul>
+      <p>Vid helger och semester kan leveranstiden bli längre. Om du kan ska du därför börja beställningen tidigt — gärna första veckan efter dödsfallet, så att intyget finns när banken eller bouppteckningsmötet behöver det.</p>
+
+      <h2>Vad kostar dödsfallsintyget?</h2>
+      <p>Ingenting. Skatteverket tar inte ut någon avgift, varken för intyget med eller utan släktutredning, och inte heller för extra kopior. Om en begravningsbyrå eller jurist erbjuder sig att beställa intyget åt dig kan de ta ut en administrativ avgift — men själva dokumentet är alltid gratis att få från Skatteverket.</p>
+
+      <h2>När i dödsboprocessen behöver du intyget?</h2>
+      <p>Intyget dyker upp i flera moment. Beställ gärna flera kopior så att du kan lämna ifrån dig original utan att begränsa dig själv.</p>
+      <ul>
+        <li><strong>Banken</strong> — för att få insyn i konton, avsluta kort, stoppa autogiron eller betala löpande räkningar. Kräver nästan alltid släktutredning.</li>
+        <li><strong>Försäkringsbolag</strong> — vid dödsfallsanmälan och begäran om utbetalning av liv- eller olycksfallsförsäkringar.</li>
+        <li><strong>Bouppteckningsförrättning</strong> — jurist eller bouppgivare behöver intyget som grund för bouppteckningen. <a href="./bouppteckning-guide.html">Läs om bouppteckning steg för steg.</a></li>
+        <li><strong>Hyresvärd</strong> — för att säga upp eller överlåta hyresrätten.</li>
+        <li><strong>Transportstyrelsen</strong> — för att avregistrera bilen eller genomföra ägarbyte.</li>
+        <li><strong>Pensionsmyndigheten och Försäkringskassan</strong> — för efterlevandepension, barnpension och för att stoppa pågående utbetalningar. <a href="./efterlevandepension.html">Mer om efterlevandepension.</a></li>
+        <li><strong>Digitala leverantörer</strong> — vissa streamingtjänster, e-postleverantörer och sociala medier vill ha intyg för att avsluta den avlidnes konton.</li>
+      </ul>
+
+      <h2>Vanliga fallgropar — och hur du undviker dem</h2>
+      <ol>
+        <li><strong>Att förväxla dödsbeviset med dödsfallsintyget.</strong> Om banken ber om "intyg" menar de nästan alltid dödsfallsintyget från Skatteverket. Skicka aldrig läkarens dödsbevis som svar.</li>
+        <li><strong>Att beställa enkelt intyg när du behöver släktutredning.</strong> Om du ska göra bouppteckning, hantera banken eller sälja bostad — välj alltid släktutredning direkt.</li>
+        <li><strong>Att bara beställa en kopia.</strong> Flera aktörer vill ha original. Beställ minst tre–fem kopior samtidigt, det kostar inget extra.</li>
+        <li><strong>Att vänta för länge.</strong> Banken kan behöva intyget för att betala löpande räkningar från dödsboet. Beställ så snart Skatteverkets registrering är klar.</li>
+        <li><strong>Att glömma digital leverans.</strong> Om du har Kivra eller Min myndighetspost får du intyget samma dag istället för att vänta på posten.</li>
+      </ol>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Kan jag beställa dödsfallsintyg för någon jag inte är släkt med?</h3>
+      <p>Ja, enkelt dödsfallsintyg kan beställas av vem som helst — det är en offentlig handling. Dödsfallsintyg med släktutredning kan också beställas av utomstående, men används i praktiken nästan bara av personer som företräder dödsboet. Om du är ombud för en dödsbodelägare behöver du fullmakt för att agera i ärenden som kräver släktutredningen.</p>
+
+      <h3>Får jag dödsfallsintyget på engelska?</h3>
+      <p>Ja. Skatteverket utfärdar internationellt dödsfallsintyg (på engelska, tyska eller franska) när den avlidne hade tillgångar eller skulder utomlands. Be uttryckligen om det — det tar längre tid än det svenska intyget.</p>
+
+      <h3>Vad gör jag om informationen på intyget är fel?</h3>
+      <p>Kontakta Skatteverket direkt och be om rättelse. Fel i folkbokföringen, som felaktigt personnummer eller adress, rättas i källsystemet och sedan utfärdas ett nytt intyg. Lämna aldrig ett felaktigt intyg vidare.</p>
+
+      <h3>Vad händer om jag tappar bort intyget?</h3>
+      <p>Beställ en ny kopia. Det finns ingen begränsning för hur många kopior du får beställa, och det är alltid kostnadsfritt.</p>
+
+      <div class="seo-cta">
+        <p>Samla allt på ett ställe — dödsfallsintyg, bouppteckning, bank, försäkringar och arv</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · <a href="/om.html">Om</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./vad-gora-nar-nagon-dor.html">Vad gör man när någon dör?</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./bankkonto-dodsfall.html">Bankkonto vid dödsfall</a> &nbsp;·&nbsp;
+      <a href="./efterlevandepension.html">Efterlevandepension</a> &nbsp;·&nbsp;
+      <a href="./fullmakt-dodsbo.html">Fullmakt dödsbo</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/laglott.html
+++ b/laglott.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Laglott 2026 — bröstarvingars rätt till halva arvet, exempel och jämkning | Efterplan</title>
+  <meta name="description" content="Laglott: vad den är, hur den räknas, vilka barn som har rätt till den och hur du jämkar testamente för att få ut laglotten. Tre räkneexempel och tidsgränser.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/laglott.html">
+  <meta property="og:title" content="Laglott — bröstarvingars skyddade del av arvet">
+  <meta property="og:description" content="Komplett guide till laglotten: definition, räkneexempel, jämkning av testamente och skillnader mot make/sambo.">
+  <meta property="og:url" content="https://efterplan.se/laglott.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" as="style"
+        href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    @media print {
+      .seo-nav, .seo-cta, .seo-footer-links { display: none; }
+      .seo-main { max-width: 100%; padding: 0; }
+      .seo-article a { color: inherit; text-decoration: none; }
+      body { background: #fff; color: #000; }
+    }
+  </style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Laglott — bröstarvingars rätt till halva arvet, exempel och jämkning",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-22",
+    "dateModified": "2026-04-22",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/laglott.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Vad är laglott?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Laglotten är den del av arvet som bröstarvingar (barn, adopterade barn och deras efterkommande) alltid har rätt till, oavsett vad som står i ett testamente. Laglotten motsvarar hälften av arvslotten — det vill säga halva den andel barnet skulle ha ärvt om det inte fanns något testamente." }
+      },
+      {
+        "@type": "Question",
+        "name": "Hur stor är laglotten?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Laglotten är alltid hälften av arvslotten. Har den avlidne två barn är varje barns arvslott 50 procent av kvarlåtenskapen, och laglotten därmed 25 procent per barn. Har den avlidne fyra barn är arvslotten 25 procent och laglotten 12,5 procent per barn." }
+      },
+      {
+        "@type": "Question",
+        "name": "Hur gör man för att få ut laglotten när det finns testamente?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Du måste aktivt begära jämkning av testamentet. Det görs skriftligt och måste nå testamentstagaren eller boutredaren inom sex månader från att du delgivits testamentet. Missar du sexmånadersfristen förlorar du rätten till laglotten och testamentet gäller i sin helhet." }
+      },
+      {
+        "@type": "Question",
+        "name": "Har särkullbarn rätt till laglott?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja. Särkullbarn — barn som inte är gemensamma med den efterlevande maken — har samma rätt till laglott som övriga bröstarvingar. De har dessutom rätt att få ut sin laglott direkt vid dödsfallet, utan att behöva vänta på att den efterlevande maken också avlider." }
+      },
+      {
+        "@type": "Question",
+        "name": "Kan jag testamentera bort allt till välgörenhet?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Bara om du saknar bröstarvingar. Har du barn kan du testamentera bort maximalt hälften av din egendom — den andra hälften är skyddad som laglott åt bröstarvingarna. Utan barn (och utan efterlevande make med giftorättsgods) kan hela kvarlåtenskapen testamenteras fritt." }
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Efterplan", "item": "https://efterplan.se/" },
+      { "@type": "ListItem", "position": 2, "name": "Laglott", "item": "https://efterplan.se/laglott.html" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Laglott — bröstarvingars rätt till halva arvet</h1>
+
+      <p>Laglotten är den svenska arvsrättens viktigaste skydd för barn. Oavsett vad som står i ett testamente har bröstarvingar alltid rätt till hälften av det de skulle ha ärvt om testamentet inte fanns. Den här guiden går igenom vad laglott innebär i praktiken, hur stor den är, vilka som omfattas, räkneexempel med kronor — och exakt hur du begär ut laglotten om den avlidne testamenterade bort egendom till någon annan.</p>
+
+      <h2>Vad är laglott?</h2>
+      <p>Laglotten är en del av arvsrätten enligt ärvdabalken kapitel 7. Regeln kan sammanfattas så här: om en förälder skriver ett testamente som ger bort hela eller delar av arvet till någon annan — en ny partner, en välgörenhetsorganisation, ett barnbarn — har bröstarvingarna rätt att kräva ut halva sin arvslott ändå. Den halvan kallas laglott, och är skyddad.</p>
+      <p>Skyddet är absolut: testamentet kan inte skrivas så att laglotten försvinner. Men bröstarvingen måste själv aktivt begära ut laglotten genom så kallad jämkning — gör hon inte det inom sex månader, går testamentet igenom som skrivet.</p>
+
+      <h2>Hur stor är laglotten?</h2>
+      <p>Laglotten är alltid exakt hälften av arvslotten. Arvslotten är den andel bröstarvingen skulle ärvt om det inte fanns testamente. Antalet bröstarvingar styr storleken:</p>
+      <ul>
+        <li><strong>1 barn:</strong> arvslott 100 %, laglott 50 % av kvarlåtenskapen.</li>
+        <li><strong>2 barn:</strong> arvslott 50 %, laglott 25 % per barn (sammanlagt 50 % bundet).</li>
+        <li><strong>3 barn:</strong> arvslott ca 33,3 %, laglott ca 16,7 % per barn (sammanlagt 50 %).</li>
+        <li><strong>4 barn:</strong> arvslott 25 %, laglott 12,5 % per barn (sammanlagt 50 %).</li>
+      </ul>
+      <p>Kvarlåtenskap är det som återstår efter att skulder betalats och eventuell bodelning gjorts med efterlevande make. Laglotten räknas alltid i procent av nettoförmögenheten, inte på bruttovärdet.</p>
+
+      <h2>Vem har rätt till laglott?</h2>
+      <p>Bara bröstarvingar har laglottsskydd. Med bröstarvinge avses:</p>
+      <ul>
+        <li><strong>Biologiska barn</strong> till den avlidne, oavsett ålder, civilstånd eller relation.</li>
+        <li><strong>Adopterade barn</strong>, som juridiskt jämställs med biologiska barn.</li>
+        <li><strong>Särkullbarn</strong> — barn från tidigare förhållande som inte är gemensamma med efterlevande make. <a href="./sarkullbarn.html">Läs mer om särkullbarns rättigheter.</a></li>
+        <li><strong>Barnbarn (istadarätt)</strong> — om ett barn till den avlidne har dött före föräldern, träder barnbarnen in i förälderns ställe och delar på den förälderns laglott.</li>
+      </ul>
+      <p>Make, sambo, föräldrar, syskon och syskonbarn har ingen laglott. De kan visserligen ärva enligt den legala arvsordningen om det inte finns testamente, men testamentet kan avsluta hela deras rätt utan att de kan göra något åt det. <a href="./sambo-arv.html">Se vår guide om sambos och arv.</a></p>
+
+      <h2>Räkna ut laglotten — tre exempel</h2>
+      <p>Räknemetoden är enkel: summera kvarlåtenskapen, dela med antal bröstarvingar för att få arvslotten, halvera för att få laglotten.</p>
+
+      <h3>Exempel 1 — två barn och ett välgörenhetstestamente</h3>
+      <p>Anna efterlämnar 1 000 000 kr efter att skulder betalats. Hon har skrivit testamente som ger hela arvet till Rädda Barnen. Hennes två barn, Elin och Johan, vill begära ut sin laglott.</p>
+      <ul>
+        <li>Kvarlåtenskap: 1 000 000 kr.</li>
+        <li>Arvslott per barn: 500 000 kr (50 %).</li>
+        <li>Laglott per barn: 250 000 kr (25 %).</li>
+      </ul>
+      <p>Elin och Johan får 250 000 kr vardera om de jämkar testamentet. Rädda Barnen får kvarvarande 500 000 kr.</p>
+
+      <h3>Exempel 2 — särkullbarn och gemensamma barn</h3>
+      <p>Gustav avlider och efterlämnar 2 000 000 kr. Han har ett särkullbarn, Lovisa, från ett tidigare förhållande, och två gemensamma barn med makan Karin. Gustav har testamenterat 500 000 kr direkt till en vän.</p>
+      <ul>
+        <li>Kvarlåtenskap: 2 000 000 kr.</li>
+        <li>Arvslott per barn: 2 000 000 / 3 = 666 667 kr.</li>
+        <li>Laglott per barn: 333 333 kr.</li>
+      </ul>
+      <p>Testamentet tar 500 000 kr, vilket minskar utdelningen till barnen. Om Lovisa jämkar testamentet har hon rätt att få ut sin laglott på 333 333 kr direkt från dödsboet. De gemensamma barnens arv hanteras tillsammans med Karins efterlevandeskydd och utbetalas oftast efter Karins död — men även de skulle kunna jämka testamentet om de vill skydda sin laglott explicit.</p>
+
+      <h3>Exempel 3 — ett barn och totalt testamente</h3>
+      <p>Ingrid har ett barn, Sara, och har testamenterat allt till sin systerdotter. Ingrids kvarlåtenskap är 800 000 kr.</p>
+      <ul>
+        <li>Kvarlåtenskap: 800 000 kr.</li>
+        <li>Arvslott: 800 000 kr (100 %).</li>
+        <li>Laglott: 400 000 kr (50 %).</li>
+      </ul>
+      <p>Sara kan jämka testamentet och få 400 000 kr. Systerdottern får de resterande 400 000 kr.</p>
+
+      <h2>Så jämkar du ett testamente för att få ut laglotten</h2>
+      <p>Laglotten måste begäras aktivt — den betalas inte ut automatiskt. Processen kallas jämkning av testamente och innebär att bröstarvingen skriftligen meddelar att hon gör anspråk på sin laglott.</p>
+
+      <h3>Tidsgränsen: sex månader</h3>
+      <p>Begäran om jämkning ska framställas inom sex månader från den dag bröstarvingen delgavs testamentet. Delgivning sker oftast genom att testamentsexekutorn eller boutredningsmannen skickar en kopia av testamentet rekommenderat. Först vid den dagen startar sexmånadersklockan. Missar du fristen förlorar du laglotten.</p>
+
+      <h3>Så skriver du jämkningsbegäran</h3>
+      <p>Begäran behöver inte vara komplicerad men måste vara skriftlig. Den bör innehålla:</p>
+      <ol>
+        <li>Ditt namn och personnummer.</li>
+        <li>Den avlidnes namn, personnummer och dödsdatum.</li>
+        <li>En tydlig förklaring: "Jag begär härmed jämkning av testamentet och anspråk på min laglott."</li>
+        <li>Datum och signatur.</li>
+      </ol>
+      <p>Skicka begäran rekommenderat till testamentstagaren eller boutredningsmannen — du behöver kunna bevisa att den kommit fram i tid. Ta alltid en kopia för egen del.</p>
+
+      <h3>Vad händer sedan?</h3>
+      <p>Efter jämkningsbegäran beräknas laglotten som en del av den slutliga arvskiftesfördelningen. Om dödsboet har kontanter räcker oftast en kontantutbetalning; annars kan fastighet eller värdepapper behöva säljas, eller arvingen få ut sin laglott i form av egendom. Det ingår i det ordinarie <a href="./arvskifte-guide.html">arvskiftet</a>.</p>
+
+      <h2>Om laglotten inte jämkas</h2>
+      <p>Konsekvensen är bindande: utan jämkning inom sex månader verkställs testamentet som skrivet. Det händer oftare än man tror — ibland för att arvingen inte förstår att det krävs aktivt anspråk, ibland för att konflikt i familjen gör det obekvämt, och ibland för att bröstarvingen medvetet väljer att låta testamentet gå igenom för att hedra den avlidnes vilja.</p>
+      <p>En bröstarvinge som är osäker bör alltid rådgöra med jurist så tidigt som möjligt. Kostnaden är ofta låg jämfört med det belopp som står på spel.</p>
+
+      <h2>Laglott kontra efterlevande make</h2>
+      <p>Efterlevande make har ett starkt ekonomiskt skydd genom att ärva med så kallad fri förfoganderätt — men inte genom laglott. Skillnaden har betydelse vid konflikt:</p>
+      <ul>
+        <li>Make ärver gemensamma barns arv med fri förfoganderätt tills maken också avlider; barnen får då efterarv.</li>
+        <li>Särkullbarn har rätt att få ut sin laglott direkt vid förälderns död, även om förälderns make lever kvar.</li>
+        <li>Make har rätt till grundavdrag på fyra prisbasbelopp ur kvarlåtenskapen om boet är litet — men det påverkar inte bröstarvingarnas laglottsrätt.</li>
+      </ul>
+      <p>Kombinationen särkullbarn + testamente är den vanligaste konfliktpunkten. Där hjälper tydlighet: skriv testamente, förklara bakgrunden, och räkna med att särkullbarnen kan jämka.</p>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Kan jag avstå från laglott medvetet?</h3>
+      <p>Ja. En bröstarvinge kan skriva ett arvsavstående och därmed avstå från både sin arvslott och laglott, eller bara delar av den. Avståendet måste vara skriftligt och bör bevittnas. Många avstår till förmån för sina egna barn (istadarätt) eller till förmån för efterlevande förälder.</p>
+
+      <h3>Gäller laglott för barnbarn om barnet lever?</h3>
+      <p>Nej. Barnbarnet får rätt till laglott bara om den mellanliggande bröstarvingen (dess förälder) har avlidit före arvlåtaren. Då träder barnbarnet in i förälderns ställe genom istadarätt.</p>
+
+      <h3>Hur påverkar förskott på arv laglotten?</h3>
+      <p>Förskott räknas in i kvarlåtenskapen vid laglottsberäkningen, om inte den avlidne uttryckligen angett att gåvan inte ska räknas som förskott. Ett barn som fått stora gåvor i livstid kan alltså få en lägre slutlig utbetalning.</p>
+
+      <h3>Kan ett testamente göras så att laglotten ersätts med något annat?</h3>
+      <p>Inte utan bröstarvingens samtycke. Den avlidne kan erbjuda laglotten i form av en specifik tillgång — till exempel sommarstugan — men bröstarvingen behöver inte acceptera det om värdet är lägre än den kontanta laglotten.</p>
+
+      <div class="seo-cta">
+        <p>Osäker på vad som gäller i just ditt dödsbo? Få en checklista som passar din situation</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · <a href="/om.html">Om</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
+      <a href="./sarkullbarn.html">Särkullbarn</a> &nbsp;·&nbsp;
+      <a href="./sambo-arv.html">Sambos och arv</a> &nbsp;·&nbsp;
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./arvsskatt.html">Arvsskatt</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/saga-upp-hyresratt-dodsbo.html
+++ b/saga-upp-hyresratt-dodsbo.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Säga upp hyresrätt vid dödsfall 2026 — 1 månads uppsägningstid, mall och steg | Efterplan</title>
+  <meta name="description" content="Säga upp hyresrätt dödsbo: så utnyttjar du den särskilda 1-månadsuppsägningen vid dödsfall. Mall för uppsägningsbrev, fullmakt, överlåtelse till anhörig och praktiska steg.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/saga-upp-hyresratt-dodsbo.html">
+  <meta property="og:title" content="Säga upp hyresrätt vid dödsfall — steg, mall och fullmakt">
+  <meta property="og:description" content="Så säger dödsboet upp hyresrätten på 1 månad. Mall, fullmakt och överlåtelse till anhörig.">
+  <meta property="og:url" content="https://efterplan.se/saga-upp-hyresratt-dodsbo.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" as="style"
+        href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    @media print {
+      .seo-nav, .seo-cta, .seo-footer-links { display: none; }
+      .seo-main { max-width: 100%; padding: 0; }
+      .seo-article a { color: inherit; text-decoration: none; }
+      body { background: #fff; color: #000; }
+    }
+  </style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "name": "Säga upp hyresrätt vid dödsfall",
+    "description": "Hur dödsboet säger upp en hyresrätt med 1 månads uppsägningstid enligt jordabalken.",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-22",
+    "dateModified": "2026-04-22",
+    "totalTime": "PT30M",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/saga-upp-hyresratt-dodsbo.html" },
+    "step": [
+      { "@type": "HowToStep", "position": 1, "name": "Beställ dödsfallsintyg", "text": "Beställ dödsfallsintyg med släktutredning från Skatteverket. Hyresvärden behöver intyget för att kunna ta emot uppsägningen från dödsboet." },
+      { "@type": "HowToStep", "position": 2, "name": "Samla dödsbodelägarna", "text": "Alla dödsbodelägare måste vara överens om uppsägningen. Om någon inte kan signera krävs fullmakt." },
+      { "@type": "HowToStep", "position": 3, "name": "Skriv uppsägningsbrevet", "text": "Skriv ett skriftligt uppsägningsbrev med den avlidnes namn och personnummer, lägenhetens adress, dödsdatum och hänvisning till 1-månadsregeln i jordabalken 12 kap 5 §." },
+      { "@type": "HowToStep", "position": 4, "name": "Skicka rekommenderat", "text": "Skicka uppsägningen rekommenderat till hyresvärden tillsammans med kopia av dödsfallsintyget. Bevara kvitto och ev. delgivningsbevis." },
+      { "@type": "HowToStep", "position": 5, "name": "Planera flyttstädning och besiktning", "text": "Koordinera med hyresvärden kring utflyttningsdag, besiktning och flyttstädning. Allt ska vara klart vid månadens slut." }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Hur lång uppsägningstid gäller när hyresgästen har avlidit?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Om dödsboet säger upp hyresavtalet inom en månad från dödsfallet gäller enligt jordabalken 12 kap 5 § en särskild uppsägningstid på en månad, räknat från närmaste månadsskifte efter uppsägningen. Säger dödsboet upp senare gäller den vanliga uppsägningstiden — oftast tre månader." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vem har rätt att säga upp hyresrätten för dödsboet?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Alla dödsbodelägare måste vara överens och underteckna uppsägningen gemensamt, alternativt utse en av dem med fullmakt att underteckna för de övrigas räkning. Även testamentsexekutor eller boutredningsman kan säga upp avtalet." }
+      },
+      {
+        "@type": "Question",
+        "name": "Kan en anhörig överta den avlidnes hyresrätt?",
+        "acceptedAnswer": { "@type": "Answer", "text": "En närstående som varit folkbokförd och sammanboende i lägenheten i minst tre år kan ha rätt att överta kontraktet, förutsatt att hyresvärden godkänner det. Make, sambo och barn under 18 har i regel starkast rätt. Vuxna barn som inte bott permanent i lägenheten har sällan rätt att överta kontraktet." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vem betalar hyran under uppsägningstiden?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Dödsboet betalar hyran fram till och med sista dagen av uppsägningstiden. Pengarna tas ur dödsboets tillgångar, inte från arvingarna personligen. Om det inte finns medel i dödsboet kan hyresvärden bli en av flera borgenärer som får stå tillbaka." }
+      },
+      {
+        "@type": "Question",
+        "name": "Måste lägenheten vara tömd och städad vid utflyttningsdagen?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja. Bostaden ska vara tömd och flyttstädad senast på avtalsdagens slut. Om så inte är fallet kan hyresvärden kräva dödsboet på kostnad för extra städning, slutbesiktning och dubbelhyra tills lägenheten är hanterbar för nästa hyresgäst." }
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Efterplan", "item": "https://efterplan.se/" },
+      { "@type": "ListItem", "position": 2, "name": "Säga upp hyresrätt dödsbo", "item": "https://efterplan.se/saga-upp-hyresratt-dodsbo.html" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Säga upp hyresrätt vid dödsfall — så gör du steg för steg</h1>
+
+      <p>När en hyresgäst avlider upphör inte kontraktet automatiskt. Dödsboet tar över både rätten och skyldigheten, och fortsätter betala hyra tills kontraktet sägs upp. Bra nyheter: svensk lag ger dödsboet en särskild förmån — om uppsägningen sker inom en månad från dödsfallet gäller bara en månads uppsägningstid, istället för de vanliga tre. Den här guiden visar hur ni utnyttjar den regeln, vilka dokument ni behöver och hur ni skriver själva uppsägningsbrevet.</p>
+
+      <h2>Särskild regel vid dödsfall: en månads uppsägningstid</h2>
+      <p>Huvudregeln i hyreslagen är att en hyresrätt sägs upp med tre månaders uppsägningstid. Men <strong>jordabalken 12 kap 5 §</strong> ger en viktig lättnad: om dödsboet säger upp avtalet inom en månad från dödsfallet, förkortas uppsägningstiden till en månad räknat från närmaste månadsskifte efter uppsägningen.</p>
+      <p>Exempel: Hyresgästen avlider 3 maj. Dödsboet skickar skriftlig uppsägning den 20 maj (inom en månad från dödsfallet). Uppsägningstiden räknas från närmaste månadsskifte — alltså 31 maj — och sträcker sig till och med 30 juni. Flyttdagen blir senast 30 juni och dödsboet slipper betala hyra i juli och augusti.</p>
+      <p>Säger dödsboet upp senare än en månad efter dödsfallet gäller istället den vanliga uppsägningstiden, oftast tre månader. För en hyresrätt i storstad kan skillnaden innebära 15 000–40 000 kr i hyra, el och avgifter. Handla alltså snabbt.</p>
+
+      <h2>Vem har rätt att säga upp kontraktet?</h2>
+      <p>Hyreskontraktet tillhör dödsboet, och dödsbodelägarna förvaltar det gemensamt. I praktiken innebär det tre alternativ:</p>
+      <ul>
+        <li><strong>Alla dödsbodelägare undertecknar uppsägningen.</strong> Det är det enklaste om ni är få och enade.</li>
+        <li><strong>En dödsbodelägare undertecknar med fullmakt från övriga.</strong> Passar när någon bor långt bort eller processen ska gå snabbt. <a href="./fullmakt-dodsbo.html">Se vår mall för fullmakt i dödsbo.</a></li>
+        <li><strong>Boutredningsman eller testamentsexekutor undertecknar.</strong> Om tingsrätten har utsett en boutredningsman, eller om det finns en testamentsexekutor, kan den personen agera ensam för dödsboets räkning. <a href="./boutredningsman.html">Läs mer om boutredningsman.</a></li>
+      </ul>
+      <p>En enskild arvinge kan inte säga upp kontraktet ensam utan stöd av övriga delägare eller fullmakt. Gör man det ändå kan uppsägningen bli ogiltig och månaderna börja om.</p>
+
+      <h2>Steg-för-steg: så säger dödsboet upp kontraktet</h2>
+
+      <h3>Steg 1 — Beställ dödsfallsintyg med släktutredning</h3>
+      <p>Hyresvärden kommer kräva dödsfallsintyget för att registrera uppsägningen. Välj varianten med släktutredning, så att hyresvärden kan se vilka dödsbodelägarna är och verifiera att rätt personer har undertecknat. <a href="./dodsfallsintyg.html">Så beställer du dödsfallsintyget.</a></p>
+
+      <h3>Steg 2 — Samla dödsbodelägarna och ta beslut</h3>
+      <p>Innan uppsägning måste delägarna diskutera alternativen. Ska någon överta lägenheten (se nedan)? Finns det värdesaker som kräver tid att sortera? Är alla överens om att säga upp inom en månad?</p>
+      <p>Om enighet finns, samla signaturer digitalt eller fysiskt. Om någon inte kan signera i tid, skriv en enkel fullmakt där den personen ger en annan delägare mandat att underteckna för hennes räkning.</p>
+
+      <h3>Steg 3 — Skriv uppsägningsbrevet</h3>
+      <p>Uppsägningen ska vara <strong>skriftlig</strong>. E-post räcker normalt inte — domstolar har i flera fall underkänt digital uppsägning utan signatur. Använd post, gärna rekommenderat, så att du har bevis på när hyresvärden tog emot brevet.</p>
+      <p>Brevet ska innehålla:</p>
+      <ol>
+        <li>Datum för uppsägningen.</li>
+        <li>Hyresvärdens namn och adress.</li>
+        <li>Lägenhetens gatuadress och lägenhetsnummer.</li>
+        <li>Den avlidnes namn, personnummer och dödsdatum.</li>
+        <li>Hänvisning till jordabalken 12 kap 5 § och den särskilda 1-månadsuppsägningen.</li>
+        <li>Önskad utflyttningsdag (sista dagen av uppsägningstiden).</li>
+        <li>Kontaktuppgifter till den som agerar för dödsboet.</li>
+        <li>Underskrifter från samtliga dödsbodelägare (eller undertecknande ombud med fullmakt).</li>
+      </ol>
+
+      <h3>Steg 4 — Skicka rekommenderat</h3>
+      <p>Skicka brevet rekommenderat till hyresvärden och inkludera en kopia av dödsfallsintyget. Spara kvittot och eventuellt delgivningsbevis. Om hyresvärden inte hämtar ut brevet räknas uppsägningen ändå, så länge den skickades inom månadsfristen.</p>
+
+      <h3>Steg 5 — Planera besiktning och flyttstädning</h3>
+      <p>Kontakta hyresvärden för att boka slutbesiktning och överlämning av nycklar. Flyttstädning är obligatorisk och görs antingen av dödsboet eller av ett städbolag (3 000–8 000 kr beroende på storlek). Koordinera med <a href="./tomma-dodsbo.html">tömning av bostaden</a> så att allt är klart senast på utflyttningsdagen.</p>
+
+      <h2>Mall för uppsägningsbrev</h2>
+      <p>Anpassa namn och uppgifter. Kopiera och skriv under.</p>
+
+      <blockquote>
+        <p><strong>Uppsägning av hyresavtal — [Gatuadress, lägenhetsnr]</strong></p>
+        <p>[Ort], den [datum]</p>
+        <p>[Hyresvärdens namn]<br>[Hyresvärdens adress]</p>
+        <p>Härmed säger dödsboet efter [avlidnes fullständiga namn], personnummer [ÅÅMMDD-XXXX], avliden [dödsdatum], upp hyresavtalet för bostadslägenheten på [gatuadress, lägenhetsnr, ort].</p>
+        <p>Uppsägningen sker med stöd av jordabalken 12 kap 5 § och gäller därmed med en månads uppsägningstid räknat från närmaste månadsskifte. Uppsägning görs inom en månad från dödsfallet.</p>
+        <p>Lägenheten kommer att vara tömd och flyttstädad senast [sista datum i uppsägningstiden]. Kontakta undertecknad för besiktning och överlämning av nycklar.</p>
+        <p>Bilaga: Dödsfallsintyg med släktutredning från Skatteverket.</p>
+        <p>[Undertecknandes namn och personnummer]<br>[Telefon och e-post]<br>[Signatur]</p>
+        <p>Samtliga dödsbodelägare, alternativt ombud med fullmakt:<br>[Namn + signatur för respektive delägare]</p>
+      </blockquote>
+
+      <h2>Kan en anhörig överta hyresrätten?</h2>
+      <p>Ibland vill en anhörig bo kvar istället för att säga upp kontraktet. Enligt hyreslagen kan överlåtelse medges om:</p>
+      <ul>
+        <li>Den anhörige har varit <strong>folkbokförd och sammanboende</strong> med den avlidne under tillräckligt lång tid — praxis brukar vara minst tre år för vuxna.</li>
+        <li>Hyresvärden godkänner övertagandet. Hyresvärden kan neka om den anhörige inte uppfyller kreditkrav eller om fastigheten inte tillåter flera hyresgäster.</li>
+        <li>Hyresnämnden kan pröva ärendet om hyresvärden säger nej utan rimliga skäl.</li>
+      </ul>
+      <p>Make, registrerad partner, sambo och minderåriga barn har i regel starkast rätt. Vuxna barn som inte bott permanent i lägenheten har sällan rätt att ta över kontraktet. Ansökan om överlåtelse sker skriftligt till hyresvärden och bör lämnas in så snabbt som möjligt — helst innan dödsboet säger upp avtalet, eftersom en genomförd uppsägning är svår att återta.</p>
+
+      <h2>Vad ingår i uppsägningstiden — och vad betalar dödsboet?</h2>
+      <p>Under uppsägningstiden ansvarar dödsboet för allt som hör till lägenheten:</p>
+      <ul>
+        <li><strong>Hyran</strong> betalas fram till sista dagen av uppsägningstiden.</li>
+        <li><strong>El och varmvatten</strong> fortsätter gå på den avlidnes abonnemang. Stäng dem tidigast på utflyttningsdagen — en ouppvärmd bostad vintertid kan skapa frostsprängningar.</li>
+        <li><strong>Bredband och hemförsäkring</strong> bör hållas igång tills lägenheten är tömd och slutbesiktigad, sedan avslutas.</li>
+        <li><strong>Flyttstädning</strong> är obligatorisk. Bristfällig städning kan leda till avdrag eller extra fakturering.</li>
+        <li><strong>Slutbesiktning</strong> görs ofta av hyresvärden eller fastighetsförvaltaren — var gärna med vid besiktningen.</li>
+      </ul>
+      <p>Alla kostnader betalas ur dödsboets tillgångar. Arvingarna är aldrig personligt betalningsskyldiga. Om dödsboet saknar tillgångar får hyresvärden stå tillbaka som borgenär — se vår guide om <a href="./dodsbo-skulder.html">skulder i dödsbo</a>.</p>
+
+      <h2>Vanliga misstag — och så undviker du dem</h2>
+      <ol>
+        <li><strong>Att glömma en-månadsregeln.</strong> Vänta inte med uppsägningen. Sägs kontraktet upp 32 dagar efter dödsfallet gäller tre månaders uppsägningstid, och det kan kosta tiotusentals kronor extra.</li>
+        <li><strong>Att skicka uppsägningen per e-post.</strong> Gör det skriftligt och rekommenderat — annars kan hyresvärden hävda att uppsägning inte skett.</li>
+        <li><strong>Att en arvinge signerar ensam utan fullmakt.</strong> Uppsägningen blir ogiltig och månadsfristen kan löpa ut. Samla signaturer eller ta fullmakt.</li>
+        <li><strong>Att säga upp innan övertagande är diskuterat.</strong> Om en anhörig hade rätt att överta kontraktet går den möjligheten förlorad när dödsboet sagt upp avtalet.</li>
+        <li><strong>Att inte planera tömning och flyttstädning i tid.</strong> Bostaden ska vara helt klar på utflyttningsdagen. Boka städfirma och återvinning tidigt.</li>
+      </ol>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Gäller en månads uppsägning även för andra bostäder än hyresrätt?</h3>
+      <p>Den särskilda dödsfallsregeln i jordabalken 12 kap 5 § gäller hyresrätter. För bostadsrätt, villa eller andra upplåtelseformer gäller andra regler. Bostadsrätten ingår i dödsboet och övergår till arvingarna vid arvskifte.</p>
+
+      <h3>Vad händer om uppsägningen skickas för sent?</h3>
+      <p>Då förlorar dödsboet rätten till en månads uppsägningstid och tre månaders uppsägningstid gäller istället. Hyresvärden kan inte neka uppsägningen, men dödsboet betalar hyra i två månader extra.</p>
+
+      <h3>Måste alla dödsbodelägare signera samtidigt?</h3>
+      <p>Nej. Samla signaturer via post, e-post eller digitalt. Det räcker att den slutgiltiga pappershandlingen som skickas till hyresvärden har alla signaturer — eller en signatur plus fullmakter.</p>
+
+      <h3>Kan hyresvärden säga upp kontraktet för att hyresgästen avlidit?</h3>
+      <p>Nej. Dödsfallet i sig är inte skäl för hyresvärden att säga upp avtalet. Dödsboet ska hinna avveckla lägenheten i lugn och ro och kan använda en-månadsregeln för att begränsa kostnaderna.</p>
+
+      <div class="seo-cta">
+        <p>Få hjälp att hålla koll på hyresrätt, bouppteckning och alla andra praktiska moment i dödsboet</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · <a href="/om.html">Om</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./tomma-dodsbo.html">Tömma dödsbo</a> &nbsp;·&nbsp;
+      <a href="./fullmakt-dodsbo.html">Fullmakt dödsbo</a> &nbsp;·&nbsp;
+      <a href="./boutredningsman.html">Boutredningsman</a> &nbsp;·&nbsp;
+      <a href="./dodsfallsintyg.html">Dödsfallsintyg</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-bostadsratt.html">Dödsbo bostadsrätt</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -174,4 +174,22 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://efterplan.se/dodsfallsintyg.html</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/laglott.html</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/saga-upp-hyresratt-dodsbo.html</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary

Tre nya SEO-sidor enligt samma mönster som `tomma-dodsbo.html`, med full integration av T088:s editorial-design (Fraunces + IBM Plex Sans).

| Ticket | Sida | Sökord | Ord | Schema |
|---|---|---|---|---|
| T089 | `dodsfallsintyg.html` | dödsfallsintyg | **1 209** | Article + FAQPage + Breadcrumb |
| T090 | `laglott.html` | laglott | **1 260** | Article + FAQPage + Breadcrumb |
| T091 | `saga-upp-hyresratt-dodsbo.html` | säga upp hyresrätt dödsbo | **1 278** | HowTo + FAQPage + Breadcrumb |

Alla tre inom målintervallet 1 200–1 800 ord.

### Innehåll

**T089 dodsfallsintyg.html** — reder ut förväxlingen mot läkarens dödsbevis, skillnaden mellan enkelt dödsfallsintyg och intyg med släktutredning, tre beställningskanaler (skatteverket.se, telefon 0771-567 567, servicekontor), tidsramar (3–14 dagar beroende på variant) och konkreta användningsfall (bank, bouppteckning, Transportstyrelsen, hyresvärd, Pensionsmyndigheten).

**T090 laglott.html** — definition enligt ärvdabalken kap 7, storleksberäkning (arvslott halverad), vilka som är bröstarvingar (inkl. särkullbarn och istadarätt), **tre fullt uträknade exempel i kronor** (2 barn + välgörenhet, särkullbarn + gemensamma barn, ensambarn + testamenterat bort allt), jämkningsprocessen med 6-månadersfristen och skillnad mot efterlevande makes fri förfoganderätt.

**T091 saga-upp-hyresratt-dodsbo.html** — 1-månadsregeln i jordabalken 12 kap 5 §, räkneexempel (dödsfall 3 maj → utflyttning 30 juni), vem som får säga upp, full **mall för uppsägningsbrev** (redaktionellt blockquote, copy-paste-färdig), överlåtelse till folkbokförd sambo/make enligt 3-årsregeln, vad som ingår i uppsägningstiden (hyra, el, bredband, flyttstäd).

### Tekniska krav (uppfyllda)

- ✅ Svensk varm/saklig ton, 1 200–1 800 ord per sida
- ✅ `<title>` och `<meta description>` innehåller det primära sökordet
- ✅ H1 + strukturerade H2/H3 (serif-nummer via T088-stilar)
- ✅ Schema markup: Article (T089, T090), HowTo med fem steg (T091), plus FAQPage och BreadcrumbList på alla tre
- ✅ Interna länkar till relevanta existerande sidor: bouppteckning-guide, checklista-dodsbo, bankkonto-dodsfall, efterlevandepension, arvskifte-guide, testamente-guide, sarkullbarn, sambo-arv, fullmakt-dodsbo, boutredningsman, tomma-dodsbo, dodsbo-bostadsratt, dodsbo-skulder
- ✅ Footer med `/om.html`-länk och relaterade-länkar-lista
- ✅ Inline `<style>@media print { … }</style>` per sida — döljer nav, CTA och footer-länkar, nollställer färger, tar bort länkunderline
- ✅ Ingen plain-text mailto någonstans
- ✅ Tydlig CTA till huvudverktyget (`<div class="seo-cta">`)

### Sitemap & ROADMAP

- `sitemap.xml`: tre nya `<url>`-poster med `lastmod=2026-04-22`, `priority=0.8`
- `ROADMAP.md`: tre nya rader i Fas 11 (SEO Sprint) med status `✔`

## Test plan

- [ ] Öppna varje sida och verifiera att Fraunces-rubriker och `01 →`/`02 →`-nummer renderar korrekt från T088:s stilar
- [ ] Testa att skriva ut `saga-upp-hyresratt-dodsbo.html` — nav, CTA och footer-länkar ska försvinna i print preview
- [ ] Validera schema med Google Rich Results Test på alla tre URL:er
- [ ] Kontrollera att varje intern länk leder till rätt existerande sida
- [ ] Kör Lighthouse mobile — målet är Performance ≥90 och A11y = 100 (bör fungera direkt eftersom CSS är oförändrad)
- [ ] Verifiera att sitemap.xml är giltig XML och innehåller de tre nya URL:erna
- [ ] Sökordskontroll: `dödsfallsintyg`, `laglott` och `säga upp hyresrätt dödsbo` ska förekomma i H1, första stycket och minst en H2 per respektive sida

https://claude.ai/code/session_01K9ToSKW3Db4FpCp2rRTzuD