### PR TITLE
T090-T091 laglott and saga-upp-hyresratt-dodsbo SEO pages

### DIFF
--- a/laglott.html
+++ b/laglott.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Laglott 2026 — bröstarvinges rätt, jämkning av testamente och räkneexempel | Efterplan</title>
+  <meta name="description" content="Laglott: vad den är, hur den räknas ut och hur du jämkar ett testamente för att få ut din del. Komplett guide 2026 med exempel och tidsfrister.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/laglott.html">
+  <meta property="og:title" content="Laglott — bröstarvinges skyddade del av arvet">
+  <meta property="og:description" content="Hur mycket har barn rätt till trots testamente? Så räknar du ut laglotten och så jämkar du ett testamente i tid.">
+  <meta property="og:url" content="https://efterplan.se/laglott.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Laglott — bröstarvinges skyddade del av arvet, med räkneexempel",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-05",
+    "dateModified": "2026-04-13",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/laglott.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Vad är laglott?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Laglott är den del av arvet som en bröstarvinge (barn eller barnbarn om barnet är avlidet) alltid har rätt till, oavsett vad som står i ett testamente. Laglotten är hälften av arvslotten enligt ärvdabalken 7 kap." }
+      },
+      {
+        "@type": "Question",
+        "name": "Hur mycket är laglotten?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Laglotten är alltid hälften av arvslotten. Om du som enda barn skulle ärvt hela kvarlåtenskapen (100 procent) är laglotten 50 procent. Finns det två barn är varje barns arvslott 50 procent och laglotten alltså 25 procent per barn." }
+      },
+      {
+        "@type": "Question",
+        "name": "Hur gör man för att få ut sin laglott?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Om ett testamente kränker din laglott måste du aktivt begära jämkning av testamentet. Det görs genom en skriftlig begäran till testamentstagaren inom sex månader från det att du delgavs testamentet. Annars förlorar du rätten." }
+      },
+      {
+        "@type": "Question",
+        "name": "Har särkullbarn rätt till laglott?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja. Särkullbarn har alltid rätt att få ut sin laglott direkt när föräldern dör, även om det finns en efterlevande make. Gemensamma barn får däremot vänta tills den efterlevande maken också avlidit, men kan kräva ut sin laglott om testamente gör dem arvlösa." }
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Efterplan", "item": "https://efterplan.se/" },
+      { "@type": "ListItem", "position": 2, "name": "Laglott", "item": "https://efterplan.se/laglott.html" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Laglott — bröstarvinges skyddade del av arvet</h1>
+
+      <p>Ett testamente kan ge bort mycket — men inte allt. Svensk lag ger barn ett minimiskydd som kallas laglott, och som inte ens den mest hårda förälder kan skriva bort. Här får du veta vad laglotten är, hur den räknas ut och hur du i praktiken gör för att få ut den när ett testamente försöker göra dig arvlös.</p>
+
+      <h2>Vad är laglott?</h2>
+      <p>Laglott är den del av arvet som en <strong>bröstarvinge</strong> — barn, eller barnbarn om barnet är avlidet — alltid har rätt till. Regeln finns i 7 kap. ärvdabalken och kan inte avtalas bort genom testamente. Förälderns vilja är med andra ord inte den sista instansen: bröstarvingens rätt till laglotten är starkare.</p>
+      <p>Laglotten är alltid <strong>hälften av arvslotten</strong>. Arvslotten är det du skulle ärvt enligt den vanliga arvsordningen om inget <a href="./testamente-guide.html">testamente</a> fanns.</p>
+
+      <h2>Så räknar du ut laglotten</h2>
+      <p>Formeln är enkel: ta reda på arvslotten, dela med två.</p>
+      <ul>
+        <li><strong>Ett barn:</strong> Arvslotten är 100 procent av kvarlåtenskapen → laglotten är 50 procent.</li>
+        <li><strong>Två barn:</strong> Arvslotten är 50 procent var → laglotten är 25 procent per barn.</li>
+        <li><strong>Tre barn:</strong> Arvslotten är ungefär 33,3 procent var → laglotten är cirka 16,7 procent per barn.</li>
+        <li><strong>Fyra barn:</strong> Arvslotten är 25 procent var → laglotten är 12,5 procent per barn.</li>
+      </ul>
+      <p>Exempel: Sven efterlämnar 2 000 000 kr och har tre barn. Arvslotten per barn är ungefär 666 667 kr. Laglotten per barn är hälften av det — cirka 333 333 kr. Testamenterar Sven hela kvarlåtenskapen till en vän måste vännen lämna tillbaka 3 × 333 333 kr ≈ 1 000 000 kr till barnen, om alla tre begär jämkning.</p>
+
+      <h2>Vem har rätt till laglott?</h2>
+      <p>Endast bröstarvingar har rätt till laglott. Det innebär:</p>
+      <ul>
+        <li><strong>Biologiska och adopterade barn</strong> — alltid.</li>
+        <li><strong>Barnbarn</strong> — om deras förälder (den avlidnes barn) har avlidit före den avlidne, ärver de förälderns andel genom <em>istadarätt</em>.</li>
+        <li><strong>Särkullbarn</strong> — <a href="./sarkullbarn.html">barn från tidigare relationer</a> har samma laglottsrätt som gemensamma barn, och kan dessutom få ut sin del direkt.</li>
+      </ul>
+      <p>Föräldrar, syskon, makar, sambor, styvbarn och bonusbarn har <em>inte</em> laglottsrätt. En efterlevande make ärver enligt särskilda regler men det är inte samma sak som laglott.</p>
+
+      <h2>Hur jämkar man ett testamente?</h2>
+      <p>Ett testamente som kränker laglotten är inte automatiskt ogiltigt — det gäller tills du som bröstarvinge aktivt begär att det jämkas. Gör du ingenting får testamentet full effekt, även om det strider mot ärvdabalken.</p>
+      <p>Så här går det till i praktiken:</p>
+      <ul>
+        <li><strong>1. Testamentet delges dig</strong> — du får en kopia av testamentet, oftast av testamentstagaren eller boutredningsmannen. Delgivningsdatumet är viktigt — där startar klockan.</li>
+        <li><strong>2. Skriftlig begäran om jämkning</strong> — skicka ett brev till testamentstagaren där du skriver att du påkallar jämkning av testamentet för att få ut din laglott. Skicka rekommenderat så du har bevis.</li>
+        <li><strong>3. Tidsfrist: sex månader</strong> — begäran måste vara framme inom sex månader från delgivningen. Missar du fristen förlorar du rätten till laglotten — även om du i övrigt har rätt till den.</li>
+        <li><strong>4. Laglotten räknas av på testamentstagarens del</strong> — testamentet gäller i övrigt, men testamentstagarens andel reduceras med det belopp som krävs för att dina laglottsanspråk ska tillgodoses.</li>
+      </ul>
+      <p>Begäran behöver inte innehålla ett exakt belopp. Det räcker att du tydligt anger att du gör anspråk på din laglott. Själva beräkningen sker sedan i samband med <a href="./bouppteckning-guide.html">bouppteckning</a> och <a href="./arvskifte-guide.html">arvskifte</a>.</p>
+
+      <h2>Särkullbarn och laglotten</h2>
+      <p>Särkullbarn — barn som inte är gemensamma med den avlidnes make — har en särställning. Till skillnad från gemensamma barn får de ut sitt arv direkt när föräldern dör, även om det finns en efterlevande make.</p>
+      <p>Om ett testamente är skrivet till förmån för den efterlevande maken och gör särkullbarnet arvlöst, kan barnet påkalla jämkning och få ut sin laglott direkt. Det är en av de vanligaste konfliktpunkterna i svenska dödsbon, och en av de främsta anledningarna till att testamenten skrivs om.</p>
+      <p>Särkullbarn kan också välja att <strong>avstå</strong> från sin del till förmån för den efterlevande maken. Då träder de in som efterarvingar när maken senare dör och ärver då sin del — ett sätt att ge maken ekonomisk trygghet utan att förlora rätten.</p>
+
+      <h2>Laglott och gåvor under livstiden — det förstärkta laglottsskyddet</h2>
+      <p>En förälder kan inte kringgå laglotten genom att ge bort egendom strax före sin död. I 7 kap. 4 § ärvdabalken finns det <strong>förstärkta laglottsskyddet</strong>: gåvor som till syfte och verkan påminner om ett testamente kan räknas tillbaka till kvarlåtenskapen när laglotten beräknas.</p>
+      <p>Typiska exempel:</p>
+      <ul>
+        <li>En förälder ger bort sin villa till en av sina tre barn några månader före dödsfallet.</li>
+        <li>En förälder tömmer sina bankkonton till förmån för sin nya sambo.</li>
+        <li>En förälder tecknar stora gåvor till ett syskon med villkor att barnen inte ska få något.</li>
+      </ul>
+      <p>Om gåvan bedöms likna ett testamente kan de missgynnade bröstarvingarna begära att gåvan räknas in i kvarlåtenskapen för att laglotten ska kunna tas ut. Det finns dock en tidsfrist: talan måste väckas i tingsrätten inom ett år från bouppteckningens avslutande.</p>
+
+      <h2>Förskott på arv och avräkning</h2>
+      <p>Har du fått en större gåva av din förälder under livet kan det räknas som <strong>förskott på arv</strong>. Det innebär att gåvans värde räknas av från din framtida arvslott — och därmed också från laglotten.</p>
+      <p>Huvudregeln är att gåvor till bröstarvingar presumeras vara förskott på arv, medan gåvor till andra personer presumeras inte vara det. Föräldern kan uttryckligen säga ifrån genom att skriva i ett gåvobrev att gåvan <em>inte</em> ska räknas som förskott.</p>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Kan jag göra mitt barn arvlöst?</h3>
+      <p>Nej, inte helt. Du kan testamentera bort upp till halva din kvarlåtenskap till andra, men barnet har alltid rätt till sin laglott — halva det barnet skulle fått i arv utan testamente. Ett fullständigt arvlöshetstestamente gäller bara om barnet inte påkallar jämkning inom sex månader.</p>
+
+      <h3>Vad händer om jag missar sexmånadersfristen?</h3>
+      <p>Då förlorar du rätten till laglotten, och testamentet gäller fullt ut. Fristen är strikt — det spelar ingen roll om du visste om testamentet eller ej, det är delgivningen som startar klockan. Därför är det viktigt att agera snabbt så fort du fått testamentet.</p>
+
+      <h3>Vad är skillnaden mellan arvslott och laglott?</h3>
+      <p>Arvslotten är hela den andel av kvarlåtenskapen som du skulle ärvt enligt den lagstadgade arvsordningen om inget testamente fanns. Laglotten är hälften av arvslotten och är det minsta en bröstarvinge kan få ut, oavsett testamente.</p>
+
+      <h3>Kan man avstå från sin laglott?</h3>
+      <p>Ja. Du kan avstå från laglotten antingen under arvlåtarens livstid (genom ett arvsavstående) eller efter dödsfallet. Ett avstående under livstiden kan vara bindande om det är skriftligt och undertecknat. Många väljer att avstå till förmån för sina egna barn, som då ärver i ditt ställe.</p>
+
+      <h3>Gäller laglotten även för utländska medborgare?</h3>
+      <p>Huvudregeln är att lagen i det land där den avlidne hade hemvist tillämpas. Bodde den avlidne i Sverige gäller svensk ärvdabalk och därmed laglottsreglerna — oavsett medborgarskap. Den avlidne kan dock i testamente välja lagen i ett land där hen var medborgare, vilket kan förändra utfallet helt.</p>
+
+      <h2>Praktisk checklista vid testamente som kränker din laglott</h2>
+      <p>Om du just fått ett testamente som gör dig arvlös eller kraftigt reducerar din andel, gör så här:</p>
+      <ul>
+        <li><strong>1. Notera delgivningsdatumet</strong> — skriv upp när du fick testamentet, så du vet när sexmånadersfristen löper ut.</li>
+        <li><strong>2. Läs igenom hela testamentet</strong> — avgör om det verkligen påverkar laglotten, eller om testamentet rör delar som inte kränker minimiskyddet.</li>
+        <li><strong>3. Räkna på laglotten</strong> — utgå från en grov uppskattning av kvarlåtenskapen och antalet bröstarvingar.</li>
+        <li><strong>4. Skicka skriftlig begäran om jämkning</strong> — rekommenderat brev, gärna inom de första veckorna så du slipper dra det till sista stund.</li>
+        <li><strong>5. Kontakta jurist om testamentet är komplicerat</strong> — vid misstänkta gåvor före dödsfallet, utländska tillgångar eller otydliga formuleringar.</li>
+      </ul>
+
+      <div class="seo-cta">
+        <p>Få en personlig checklista med alla steg för ditt dödsbo — inklusive frister för jämkning av testamente</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · <a href="/om.html">Om Efterplan</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./salja-dodsbo.html">Sälja dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./sarkullbarn.html">Särkullbarn</a> &nbsp;·&nbsp;
+      <a href="./sambo-arv.html">Sambo och arv</a> &nbsp;·&nbsp;
+      <a href="./arvsskatt.html">Arvsskatt Sverige</a> &nbsp;·&nbsp;
+      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/roadmap.md
+++ b/roadmap.md
@@ -427,4 +427,7 @@ Each step improves the product or the company in a meaningful way.
 
 | T083 | Weekly KPI review + new 14‑day plan | 2026‑05‑06 | Fas 11 | Growth | 🟡 | Growth | ☐ |
 | T087 | Länkbyggnad: identifiera 10 relevanta sajter för gästinlägg/omnämnanden (begravning, juridik, ekonomi) | 2026‑05‑10 | Fas 11 | SEO Audit | 🟠 | SEO | ☐ |
+| T089 | SEO-sida: dodsfallsintyg | Fas 11 | SEO Sprint | 🟡 | SEO | ✔ |
+| T090 | SEO-sida: laglott | Fas 11 | SEO Sprint | 🟡 | SEO | ✔ |
+| T091 | SEO-sida: saga-upp-hyresratt-dodsbo | Fas 11 | SEO Sprint | 🟡 | SEO | ✔ |
 

--- a/saga-upp-hyresratt-dodsbo.html
+++ b/saga-upp-hyresratt-dodsbo.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Säga upp hyresrätt dödsbo 2026 — uppsägningstid, fullmakt och steg för steg | Efterplan</title>
+  <meta name="description" content="Säga upp hyresrätt för dödsbo: 1 månads uppsägningstid vid dödsfall, vem som får skriva under, fullmakt och när närstående kan ta över kontraktet.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/saga-upp-hyresratt-dodsbo.html">
+  <meta property="og:title" content="Säga upp hyresrätt dödsbo — uppsägningstid och praktiska steg">
+  <meta property="og:description" content="Så säger dödsboet upp hyreskontraktet på rätt sätt: 1 månads uppsägningstid, fullmakt och överlåtelse till anhörig.">
+  <meta property="og:url" content="https://efterplan.se/saga-upp-hyresratt-dodsbo.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "name": "Så säger du upp en hyresrätt för ett dödsbo",
+    "description": "Steg för steg: hur ett dödsbo säger upp avlidnes hyreskontrakt med 1 månads uppsägningstid enligt Jordabalken 12 kap. 5 §.",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-05",
+    "dateModified": "2026-04-13",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "step": [
+      { "@type": "HowToStep", "name": "Samla dödsbodelägare och dödsfallsintyg", "text": "Beställ dödsfallsintyg med släktutredning från Skatteverket och identifiera samtliga dödsbodelägare." },
+      { "@type": "HowToStep", "name": "Upprätta fullmakt om en person ska signera", "text": "Om bara en dödsbodelägare ska skriva under uppsägningen behöver övriga ge skriftlig fullmakt." },
+      { "@type": "HowToStep", "name": "Skicka skriftlig uppsägning inom en månad", "text": "Uppsägningen ska vara hyresvärden tillhanda inom en månad från dödsfallet för att den förkortade uppsägningstiden på en månad ska gälla." },
+      { "@type": "HowToStep", "name": "Boka besiktning och lämna lägenheten", "text": "Stäm av med hyresvärden om slutbesiktning, städning och nyckelåterlämning." }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Vilken uppsägningstid har ett dödsbo på en hyresrätt?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Om hyresgästen avlider har dödsboet rätt att säga upp avtalet med en månads uppsägningstid, förutsatt att uppsägningen sker inom en månad från dödsfallet. Sker uppsägningen senare gäller normala regler — vanligtvis tre månaders uppsägningstid för bostadslägenhet." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vem får säga upp hyresrätten när någon har dött?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Dödsbodelägarna säger upp kontraktet gemensamt. Alla dödsbodelägare — efterlevande make, barn, testamentstagare — behöver signera, eller ge fullmakt till en av dem att underteckna på allas vägnar." }
+      },
+      {
+        "@type": "Question",
+        "name": "Kan en närstående ta över hyreskontraktet istället för att säga upp det?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja. En närstående som varaktigt sammanbodde med den avlidne kan i vissa fall få ta över hyreskontraktet enligt 12 kap. 34 § jordabalken, om hyresvärden lämnar sitt samtycke eller hyresnämnden godkänner övergången." }
+      },
+      {
+        "@type": "Question",
+        "name": "Betalar dödsboet hyra under uppsägningstiden?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ja. Hyran ska betalas ut hela uppsägningstiden även om ingen bor kvar i lägenheten. Hyran betalas av dödsboets medel, inte av enskild dödsbodelägare privat." }
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Efterplan", "item": "https://efterplan.se/" },
+      { "@type": "ListItem", "position": 2, "name": "Säga upp hyresrätt dödsbo", "item": "https://efterplan.se/saga-upp-hyresratt-dodsbo.html" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Säga upp hyresrätt för ett dödsbo — steg för steg</h1>
+
+      <p>När en hyresgäst avlider står dödsboet med ett kontrakt som löper vidare — och hyra som fortsätter ticka. Tur nog finns en särregel i jordabalken som ger dödsboet rätt att komma loss snabbt. Här är vad du behöver veta för att säga upp hyresrätten korrekt, inom rätt tid och utan att kosta dödsboet onödiga månadshyror.</p>
+
+      <h2>Uppsägningstiden är en månad — om du agerar i tid</h2>
+      <p>Huvudregeln för bostadshyra är tre månaders uppsägningstid. Men vid dödsfall gäller en särskild, kortare regel enligt <strong>12 kap. 5 § jordabalken</strong>: dödsboet har rätt att säga upp avtalet med endast <strong>en månads uppsägningstid</strong>, under ett viktigt villkor — uppsägningen måste göras <strong>inom en månad från dödsfallet</strong>.</p>
+      <p>Missar dödsboet den fristen går rätten till förkortad uppsägningstid förlorad, och den vanliga tremånadersregeln gäller istället. Skillnaden kan bli tusentals kronor i onödig hyra.</p>
+      <p>Ett räkneexempel: hyran är 9 500 kr/månad. Dör hyresgästen 3 mars och dödsboet säger upp kontraktet 28 mars, upphör avtalet en månad senare — ungefär 30 april. Dödsboet betalar två månadshyror (mars + april). Väntar dödsboet istället till 10 april med att säga upp, gäller tre månaders uppsägningstid — avtalet löper till sista juli och dödsboet betalar fem månader, alltså 28 500 kr mer.</p>
+
+      <h2>Vem får säga upp hyreskontraktet?</h2>
+      <p>Kontraktet tillhör dödsboet, inte en enskild person. Det innebär att <strong>samtliga dödsbodelägare</strong> gemensamt är behöriga att säga upp det. Dödsbodelägare är de som ärver — efterlevande make eller sambo, barn, eventuella testamentstagare och i sällsynta fall andra släktingar.</p>
+      <p>I praktiken signerar alla dödsbodelägare uppsägningen, antingen genom att alla skriver under samma dokument eller genom att en av dem agerar för övriga med fullmakt. Hyresvärden har rätt att kräva bevis på att den som skriver under verkligen representerar dödsboet — det är därför du behöver ha rätt dokumentation klar.</p>
+
+      <h2>Dokument som hyresvärden ofta vill se</h2>
+      <ul>
+        <li><strong><a href="./dodsfallsintyg.html">Dödsfallsintyg med släktutredning</a></strong> — intyget från Skatteverket som visar att personen är avliden och vilka som är närmast anhöriga. Beställs gratis hos Skatteverket.</li>
+        <li><strong>Bouppteckning</strong> — om den är klar. Innan den är registrerad räcker normalt dödsfallsintyget plus fullmakter.</li>
+        <li><strong>Fullmakt från övriga dödsbodelägare</strong> — om en person ensam ska signera uppsägningen på allas vägnar.</li>
+        <li><strong>Uppsägningen i original</strong> — skriftlig, undertecknad, gärna skickad rekommenderat så du har bevis på att den kom fram.</li>
+      </ul>
+      <p>Vissa hyresvärdar har egna blanketter för uppsägning vid dödsfall. Kolla med värden innan — det kan spara en omgång.</p>
+
+      <h2>Fullmakt mellan dödsbodelägare</h2>
+      <p>Det vanligaste i praktiken är att en dödsbodelägare — ofta ett av barnen eller efterlevande make — sköter det administrativa och att övriga ger en enkel fullmakt. Fullmakten behöver inte vara komplicerad men ska innehålla:</p>
+      <ul>
+        <li>Fullmaktsgivarens namn, personnummer och underskrift</li>
+        <li>Fullmäktigens namn och personnummer</li>
+        <li>Vad fullmakten avser — exempelvis "säga upp hyreskontrakt för lägenhet på [adress]"</li>
+        <li>Datum och ort</li>
+      </ul>
+      <p>Fullmakten kan begränsas till den specifika uppsägningen eller vara bredare och täcka hela dödsboförvaltningen. Vid bredare fullmakter rekommenderas ett neutralt vittne som också skriver under.</p>
+
+      <h2>Så säger du upp kontraktet — praktiska steg</h2>
+
+      <h3>1. Beställ dödsfallsintyg</h3>
+      <p>Ring eller besök Skatteverket och beställ ett dödsfallsintyg med släktutredning. Intyget är gratis och skickas per post, normalt inom några dagar. Du behöver det för nästan all dödsboadministration — hyresvärd, bank, försäkringsbolag.</p>
+
+      <h3>2. Samla in fullmakter</h3>
+      <p>Om inte alla dödsbodelägare kan närvara eller skriva under samma dokument, samla in skriftliga fullmakter i förväg. Det är ofta den del som drar ut på tiden — starta så snart du kan.</p>
+
+      <h3>3. Skriv uppsägningen</h3>
+      <p>Formulera ett kort, sakligt brev. Det bör innehålla:</p>
+      <ul>
+        <li>Den avlidnes namn, personnummer och dödsdatum</li>
+        <li>Lägenhetens adress och eventuellt lägenhetsnummer eller objektnummer</li>
+        <li>Hänvisning till 12 kap. 5 § jordabalken och önskad uppsägningstid på en månad</li>
+        <li>Dödsbodelägarnas namn och underskrifter (eller fullmaktstagarens underskrift)</li>
+        <li>Kontaktuppgifter för frågor och slutfaktura</li>
+        <li>Datum och ort</li>
+      </ul>
+
+      <h3>4. Skicka uppsägningen</h3>
+      <p>Skicka brevet rekommenderat till hyresvärden, eller lämna det personligen mot kvitto. Behåll en kopia och spara leveranskvittot — det är ditt bevis på att uppsägningen kom fram inom enmånadsfristen.</p>
+
+      <h3>5. Stäm av med hyresvärden</h3>
+      <p>Bekräfta skriftligt att uppsägningen är mottagen och när avtalet upphör att gälla. Boka slutbesiktning, städdag och nyckelåterlämning. Be hyresvärden skicka slutfakturan till dödsboets adress eller till den dödsbodelägare som sköter administrationen.</p>
+
+      <h2>Kan en närstående ta över kontraktet istället?</h2>
+      <p>Ja, i vissa fall. Enligt <strong>12 kap. 34 § jordabalken</strong> får en närstående som varaktigt sammanbodde med hyresgästen överta hyresrätten, om hyresnämnden eller hyresvärden godkänner det. Det gäller till exempel:</p>
+      <ul>
+        <li>Make eller sambo som bott med den avlidne i lägenheten</li>
+        <li>Barn som sammanbodde med föräldern under längre tid</li>
+        <li>Annan nära familjemedlem som haft gemensamt hushåll med hyresgästen</li>
+      </ul>
+      <p>Övertagandet är inte automatiskt — den närstående måste ansöka hos hyresvärden, som ska godkänna den nya hyresgästen. Nekar hyresvärden kan ärendet prövas av hyresnämnden, som bedömer om det är skäligt att tillåta övertagande.</p>
+      <p>Överlåtelse är ofta ett bra alternativ för den som bott med den avlidne och vill bo kvar — men det är ingen rättighet utan förhandling.</p>
+
+      <h2>Hyra under uppsägningstiden</h2>
+      <p>Hyran löper vidare under hela uppsägningstiden och ska betalas även om lägenheten står tom. Pengarna tas från dödsboets konto — inte från enskild dödsbodelägares privata ekonomi.</p>
+      <p>Om dödsboet har ont om likvida medel, kontakta hyresvärden och informera. De flesta hyresvärdar är lyhörda i dödsfallssituationer och kan acceptera en förskjuten betalningsplan så länge slutbetalning sker innan avtalet avslutas. Skulder från dödsboet kan du läsa mer om i vår guide om <a href="./dodsbo-skulder.html">dödsbo och skulder</a>.</p>
+
+      <h2>Tömma lägenheten — vad gäller?</h2>
+      <p>Lägenheten ska lämnas tom, städad och i avtalat skick på avflyttningsdagen. Det innebär:</p>
+      <ul>
+        <li>Allt lösöre ska vara borta — möbler, kläder, personliga tillhörigheter</li>
+        <li>Lägenheten ska vara flyttstädad (köksskåp, kyl, frys, spis, badrum, golv och fönster)</li>
+        <li>Eventuell förråds- eller garageplats ska tömmas</li>
+        <li>Nycklar ska återlämnas på överenskommen tidpunkt — oftast på avflyttningsdagen eller dagen efter</li>
+      </ul>
+      <p>Om dödsboet inte hinner eller orkar tömma lägenheten själva finns det bohagstömningsfirmor som gör det mot betalning. Värdesaker kan ingå i arvskiftet — se vår guide om <a href="./arvskifte-guide.html">arvskifte</a>. Har den avlidne också efterlämnat värdefullt lösöre kan det vara värt att först värdera det innan bohaget rensas.</p>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Vad händer om ingen säger upp hyresrätten?</h3>
+      <p>Avtalet fortsätter att löpa och hyran måste betalas varje månad. Dödsbodelägarna är ytterst ansvariga för dödsboets skulder, så det är inte ekonomiskt klokt att vänta. Säger ni inte upp kontraktet kan hyresvärden till slut säga upp det av "bristande betalning", men dödsboet är fortfarande skyldig att betala obetalda hyror.</p>
+
+      <h3>Kan hyresvärden säga nej till uppsägningen?</h3>
+      <p>Nej, inte om den är gjord på rätt sätt. Dödsboet har en lagstadgad rätt att säga upp avtalet enligt 12 kap. 5 § jordabalken. Hyresvärden kan bara ifrågasätta att alla dödsbodelägare är med, att fullmakten är giltig eller att uppsägningen kom in i tid.</p>
+
+      <h3>Måste uppsägningen vara skriftlig?</h3>
+      <p>Ja. Enligt hyreslagen ska uppsägning av bostadshyra vara skriftlig för att vara giltig. Muntlig uppsägning räcker inte, även om hyresvärden är medveten om dödsfallet.</p>
+
+      <h3>Kan man säga upp innan bouppteckningen är klar?</h3>
+      <p>Ja — och det bör man göra för att hinna inom enmånadsfristen. Bouppteckningen görs senare och behöver inte vara klar för att dödsboet ska kunna agera i löpande ärenden som hyresuppsägning. Dödsfallsintyget och fullmakter räcker för att hyresvärden ska acceptera uppsägningen.</p>
+
+      <h3>Gäller samma regler för förstahandskontrakt och andrahandskontrakt?</h3>
+      <p>Reglerna i jordabalken gäller förstahandskontrakt. Andrahandskontrakt är ofta reglerade i det individuella avtalet — kolla villkoren där. Vid hyresrätt i bostadsrättsförening gäller föreningens stadgar och bostadsrättslagens regler snarare än jordabalken.</p>
+
+      <div class="seo-cta">
+        <p>Få en personlig checklista med alla praktiska steg efter dödsfallet — inklusive hyresuppsägning och tidsfrister</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · <a href="/om.html">Om Efterplan</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./dodsfallsintyg.html">Dödsfallsintyg</a> &nbsp;·&nbsp;
+      <a href="./laglott.html">Laglott</a> &nbsp;·&nbsp;
+      <a href="./salja-dodsbo.html">Sälja dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./sarkullbarn.html">Särkullbarn</a> &nbsp;·&nbsp;
+      <a href="./sambo-arv.html">Sambo och arv</a> &nbsp;·&nbsp;
+      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -174,4 +174,22 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://efterplan.se/dodsfallsintyg.html</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/laglott.html</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://efterplan.se/saga-upp-hyresratt-dodsbo.html</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Ändringar
- **laglott.html** — ny SEO-sida (~1 281 ord). Täcker laglottsbegreppet, beräkning, jämkning av testamente, särkullbarn och det förstärkta laglottsskyddet. Schema: Article + FAQPage + BreadcrumbList.
- - **saga-upp-hyresratt-dodsbo.html** — ny SEO-sida (~1 234 ord). Täcker 1 månads uppsägningstid vid dödsfall (JB 12:5), vem som får signera, fullmakt, praktiska steg och övertagande. Schema: HowTo + FAQPage + BreadcrumbList.
- - **sitemap.xml** — dodsfallsintyg.html, laglott.html och saga-upp-hyresratt-dodsbo.html tillagda (lastmod 2026-04-22, priority 0.8).
- - **roadmap.md** — T089, T090, T091 markerade ✔ under Fas 11 SEO Sprint.