### PR TITLE
T089: add dodsfallsintyg SEO page

### DIFF
--- a/dodsfallsintyg.html
+++ b/dodsfallsintyg.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dödsfallsintyg 2026 — så beställer du intyg med släktutredning från Skatteverket | Efterplan</title>
+  <meta name="description" content="Dödsfallsintyg från Skatteverket: vad det är, skillnaden mot dödsfallsintyg med släktutredning, hur du beställer det gratis och var du behöver det.">
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://efterplan.se/dodsfallsintyg.html">
+  <meta property="og:title" content="Dödsfallsintyg — beställ intyg med släktutredning från Skatteverket">
+  <meta property="og:description" content="Så beställer du dödsfallsintyg med släktutredning: gratis, per post inom några dagar, nödvändigt för bank, hyresvärd och Försäkringskassan.">
+  <meta property="og:url" content="https://efterplan.se/dodsfallsintyg.html">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://efterplan.se/og.png">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-T1T40TYPQB');
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Dödsfallsintyg — så beställer du intyg med släktutredning från Skatteverket",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-05",
+    "dateModified": "2026-04-13",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://efterplan.se/dodsfallsintyg.html" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "name": "Så beställer du ett dödsfallsintyg med släktutredning",
+    "description": "Steg för steg: hur du beställer dödsfallsintyg med släktutredning från Skatteverket, gratis, per post inom några dagar.",
+    "inLanguage": "sv",
+    "datePublished": "2026-04-05",
+    "dateModified": "2026-04-13",
+    "author": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "publisher": { "@type": "Organization", "name": "Efterplan", "url": "https://efterplan.se" },
+    "image": "https://efterplan.se/og.png",
+    "step": [
+      {
+        "@type": "HowToStep",
+        "name": "Välj beställningssätt",
+        "text": "Du kan beställa via Skatteverkets webbplats (Mina sidor), per telefon 0771-567 567 eller genom att besöka ett servicekontor. Alla tre sätten är gratis."
+      },
+      {
+        "@type": "HowToStep",
+        "name": "Ange uppgifter om den avlidne",
+        "text": "Du behöver den avlidnes personnummer och i de flesta fall ditt eget personnummer som beställare. Skatteverket kontrollerar att du är behörig att ta del av intyget."
+      },
+      {
+        "@type": "HowToStep",
+        "name": "Välj variant",
+        "text": "Begär dödsfallsintyg med släktutredning (inte enbart det vanliga dödsfallsintyget) — det är denna variant som banker, hyresvärdar och myndigheter normalt kräver, eftersom den listar dödsbodelägarna."
+      },
+      {
+        "@type": "HowToStep",
+        "name": "Ta emot intyget per post",
+        "text": "Intyget skickas med vanlig post till din folkbokföringsadress, normalt inom ett par dagar. Digital version via Mina sidor kan också vara tillgänglig beroende på ärende."
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Vad är ett dödsfallsintyg?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ett dödsfallsintyg är ett officiellt dokument från Skatteverket som bekräftar att en person har avlidit. Det utfärdas ur folkbokföringen och används som bevis gentemot banker, myndigheter och andra aktörer i samband med dödsboförvaltning." }
+      },
+      {
+        "@type": "Question",
+        "name": "Vad är skillnaden mellan dödsfallsintyg och dödsfallsintyg med släktutredning?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Det vanliga dödsfallsintyget bekräftar bara att personen är avliden och anger dödsdatum. Dödsfallsintyget med släktutredning innehåller dessutom en förteckning över den avlidnes närmaste anhöriga — makes/sambos, barn och i förekommande fall föräldrar — vilket visar vem som är dödsbodelägare. Den senare varianten krävs av de flesta banker, hyresvärdar och myndigheter." }
+      },
+      {
+        "@type": "Question",
+        "name": "Kostar det något att beställa dödsfallsintyg?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Nej. Dödsfallsintyg, med eller utan släktutredning, är gratis att beställa från Skatteverket. Det kostar ingenting oavsett om du beställer via telefon, webben eller ett servicekontor." }
+      },
+      {
+        "@type": "Question",
+        "name": "Hur lång tid tar det att få dödsfallsintyget?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Normalt skickas intyget ut med vanlig post inom ett till tre vardagar från beställningen. I brådskande ärenden kan du besöka ett Skatteverkets servicekontor och i vissa fall få intyget direkt över disk." }
+      },
+      {
+        "@type": "Question",
+        "name": "Hur länge är dödsfallsintyget giltigt?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Det finns ingen formell giltighetstid, men banker och myndigheter begär ofta ett intyg som är utfärdat relativt nyligen — vanligtvis inte äldre än tre månader. Beställ ett nytt om ditt är daterat längre tillbaka." }
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Efterplan", "item": "https://efterplan.se/" },
+      { "@type": "ListItem", "position": 2, "name": "Dödsfallsintyg", "item": "https://efterplan.se/dodsfallsintyg.html" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav class="seo-nav">
+    <span class="logo-text">Efterplan</span>
+    <a href="/" class="btn-primary">Skapa din plan →</a>
+  </nav>
+
+  <main class="seo-main">
+    <article class="seo-article">
+      <h1>Dödsfallsintyg — så beställer du intyg med släktutredning från Skatteverket</h1>
+
+      <p>Bland de allra första praktiska uppgifterna efter ett dödsfall är att skaffa ett dödsfallsintyg. Det är ett kort, officiellt dokument från Skatteverket som bekräftar dödsfallet och — i sin viktigaste variant — listar närmaste anhöriga. Utan det fastnar nästan allt annat: bankkonton förblir låsta, hyresuppsägningar kan inte skrivas under och myndigheter kan inte handlägga ärendet. Här är allt du behöver veta för att beställa rätt variant, vid rätt tid.</p>
+
+      <h2>Vad är ett dödsfallsintyg?</h2>
+      <p>Ett dödsfallsintyg är ett utdrag ur Skatteverkets folkbokföring som bekräftar att en namngiven person är registrerad som avliden. Intyget innehåller den avlidnes namn, personnummer och dödsdatum. Det är ett av de dokument som öppnar upp för nästan all dödsboadministration — det visar myndigheter, banker och företag att personen faktiskt är borta och att dödsboet nu har tagit över.</p>
+      <p>Dokumentet ska inte förväxlas med ett läkarintyg om dödsorsak (som utfärdas av läkare) eller ett begravningstillstånd (som ges av Skatteverket till begravningsbyrån). Dödsfallsintyget från Skatteverket är det civilrättsliga beviset — det som används i dödsboets löpande ärenden.</p>
+
+      <h2>Två varianter: vanligt dödsfallsintyg och dödsfallsintyg med släktutredning</h2>
+      <p>Skatteverket utfärdar dödsfallsintyget i två versioner, och det är viktigt att beställa rätt:</p>
+      <ul>
+        <li><strong>Vanligt dödsfallsintyg</strong> — bekräftar enbart att personen är registrerad som avliden och anger dödsdatum. Används i sammanhang där motparten bara behöver ett bevis på att personen inte längre lever, exempelvis för avregistrering från enstaka tjänster.</li>
+        <li><strong>Dödsfallsintyg med släktutredning</strong> — innehåller utöver dödsfallet en förteckning över den avlidnes närmaste anhöriga: eventuell make eller sambo, barn (inklusive särkullbarn om sådana finns) och i förekommande fall föräldrar. Denna version visar vem som är dödsbodelägare och är den variant som banker, försäkringsbolag, hyresvärdar och myndigheter normalt kräver.</li>
+      </ul>
+      <p>I praktiken är det <strong>nästan alltid dödsfallsintyget med släktutredning</strong> du vill beställa. Det kostar inget mer och innehåller allt det vanliga intyget gör, plus den avgörande informationen om vilka som ingår i dödsboet. Beställer du enbart det vanliga intyget är risken stor att du snart måste beställa om.</p>
+
+      <h2>Vem kan beställa dödsfallsintyget?</h2>
+      <p>Dödsfallsintyget är ett offentligt dokument i den meningen att vem som helst kan se att en person är registrerad som avliden. Däremot innehåller varianten med släktutredning uppgifter om enskilda personers familjeförhållanden, vilket klassas som skyddad personuppgift.</p>
+      <p>I praktiken hanterar Skatteverket beställningar från:</p>
+      <ul>
+        <li>Dödsbodelägare — make, sambo, barn och andra arvingar</li>
+        <li>Ombud eller dödsboförvaltare med fullmakt</li>
+        <li>Begravningsbyråer på uppdrag av dödsboet</li>
+        <li>Advokater och jurister med uppdrag i dödsboet</li>
+      </ul>
+      <p>Du behöver normalt inte visa upp någon formell fullmakt för att beställa intyget, men du kan behöva styrka din relation till den avlidne om Skatteverket begär det. I de allra flesta fall räcker det att du anger din relation och ditt eget personnummer.</p>
+
+      <h2>Så beställer du — steg för steg</h2>
+
+      <h3>1. Via Skatteverkets webbplats</h3>
+      <p>Gå till Skatteverket.se och logga in på Mina sidor med BankID. Under avsnittet för dödsfall och dödsbo finns en digital beställningstjänst. Du anger den avlidnes personnummer, väljer variant (med släktutredning) och skickar in beställningen. Intyget skickas med post till din folkbokföringsadress inom ett till tre vardagar.</p>
+
+      <h3>2. Per telefon</h3>
+      <p>Ring Skatteverkets skatteupplysning på <strong>0771-567 567</strong> (vardagar 8–18, kortare öppettider röda dagar). Berätta att du vill beställa ett dödsfallsintyg med släktutredning, uppge den avlidnes personnummer och dina kontaktuppgifter. Handläggaren registrerar beställningen och intyget postas till dig.</p>
+
+      <h3>3. Besök servicekontor</h3>
+      <p>Du kan besöka ett Skatteverkets servicekontor i närheten. Ta med dig den avlidnes personnummer och giltig legitimation. På kontoret kan du i vissa fall få hjälp med att få intyget expedierat snabbare, och handläggare kan svara på frågor om vad som händer härnäst i dödsboprocessen.</p>
+
+      <h3>Kostnad och leverans</h3>
+      <p>Dödsfallsintyget är <strong>gratis</strong> oavsett vilket beställningssätt du väljer. Det skickas med vanlig post och brukar komma fram inom ett par dagar. I undantagsfall, till exempel vid akut behov av att säga upp ett hyreskontrakt inom enmånadsfristen (mer om det i vår guide om att <a href="./saga-upp-hyresratt-dodsbo.html">säga upp hyresrätt för dödsbo</a>), är det snabbast att besöka ett servicekontor direkt.</p>
+
+      <h2>Var används dödsfallsintyget?</h2>
+      <p>Intyget behövs i nästan alla kontakter med myndigheter och företag i dödsboets namn. De vanligaste användningsområdena:</p>
+      <ul>
+        <li><strong>Bank och finans</strong> — för att frysa eller avsluta konton, ta ut medel ur dödsboets konton och avregistrera kort och autogiro. Banken vill se dödsfallsintyget med släktutredning för att kunna identifiera vem som är dödsbodelägare och behörig att agera.</li>
+        <li><strong>Försäkringsbolag</strong> — för att anmäla dödsfall, avsluta hemförsäkring och begära utbetalning av eventuellt livförsäkringsbelopp eller begravningshjälp.</li>
+        <li><strong>Hyresvärd</strong> — för att styrka dödsfallet och dödsboets rätt att säga upp eller överlåta hyreskontraktet. Se vidare i vår guide om <a href="./saga-upp-hyresratt-dodsbo.html">hyresuppsägning vid dödsfall</a>.</li>
+        <li><strong>El, internet och prenumerationer</strong> — för att avsluta löpande abonnemang i den avlidnes namn. De flesta leverantörer kräver ett bevis på dödsfallet innan de avslutar eller överlåter avtalet.</li>
+        <li><strong>Försäkringskassan</strong> — för att avregistrera den avlidne från eventuella ersättningar och initiera utbetalning av dödsfallsrelaterade förmåner till anhöriga.</li>
+        <li><strong>Pensionsmyndigheten</strong> — för att avsluta pensionsutbetalningar och ansöka om efterlevandeskydd eller änkepension om sådana förmåner finns.</li>
+        <li><strong>Bouppteckning</strong> — intyget bifogas normalt till de handlingar som samlas in inför <a href="./bouppteckning-guide.html">bouppteckningen</a>, som ska göras inom tre månader från dödsfallet.</li>
+      </ul>
+      <p>Ha gärna flera exemplar till hands. Originalet stannar hos dig, men det kan vara praktiskt att skanna in intyget och skicka digitala kopior till aktörer som godtar det — annars behöver du beställa om varje gång.</p>
+
+      <h2>Hur länge är dödsfallsintyget giltigt?</h2>
+      <p>Det finns ingen formell giltighetstid lagstadgad. Dödsfallsintyget visar ett faktum som inte ändras: att personen är registrerad som avliden och när det skedde. I teorin är ett intyg från 2010 lika korrekt som ett utfärdat idag.</p>
+      <p>I praktiken begär dock banker och myndigheter ofta ett <strong>relativt nyligt intyg</strong> — vanligtvis inte äldre än tre månader. Motiveringen är att uppgifterna i folkbokföringen kan ha kompletterats, exempelvis om ytterligare dödsbodelägare har identifierats i efterhand. Om du beställde ett intyg tidigt i processen och sedan ärenden dragit ut på tiden, kan det vara värt att beställa ett nytt.</p>
+
+      <h2>Dödsfallsintyg eller bouppteckning — vad är vad?</h2>
+      <p>En vanlig förvirring är skillnaden mellan dödsfallsintyget och <a href="./bouppteckning-guide.html">bouppteckningen</a>. De fyller helt olika funktioner:</p>
+      <ul>
+        <li><strong>Dödsfallsintyget</strong> är ett snabbt, gratis utdrag ur folkbokföringen. Det bekräftar dödsfallet och listar närmaste anhöriga. Det kan beställas direkt efter dödsfallet och används löpande för praktiska ärenden.</li>
+        <li><strong>Bouppteckningen</strong> är ett juridiskt dokument som redovisar den avlidnes samtliga tillgångar och skulder vid tidpunkten för dödsfallet. Den upprättas av dödsbodelägarna (ofta med hjälp av jurist), ska vara klar inom tre månader och registreras hos Skatteverket. Bouppteckningen krävs för att genomföra ett <a href="./arvskifte-guide.html">arvskifte</a>.</li>
+      </ul>
+      <p>I den praktiska ordningen beställer du dödsfallsintyget <em>först</em> — det är det dokument som behövs för att komma igång med allt annat, inklusive förberedelserna för bouppteckningen. Bouppteckningen är steget som formellt fastställer dödsboets ekonomiska bild och möjliggör arvskiftet.</p>
+
+      <h2>Vanliga frågor</h2>
+
+      <h3>Kan jag beställa dödsfallsintyget innan begravningen?</h3>
+      <p>Ja, och ofta är det klokt att göra det tidigt. Dödsfallet registreras i folkbokföringen normalt inom ett par dagar från att läkarintyget om dödsorsak är inskickat. Så fort personen är registrerad som avliden kan du beställa dödsfallsintyget. Det behövs bland annat för att komma igång med hyresuppsägning, bankkontakter och avregistrering av abonnemang.</p>
+
+      <h3>Vad händer om den avlidne hade skyddad folkbokföring?</h3>
+      <p>Om den avlidne hade sekretessmarkering eller skyddad folkbokföring kan det ta längre tid och kräva personligt besök hos Skatteverket. I sådana ärenden hänvisar Skatteverket ofta till en handläggare med särskild behörighet. Kontakta skatteupplysningen för vägledning i det specifika ärendet.</p>
+
+      <h3>Kan dödsfallsintyget skickas till en annan adress?</h3>
+      <p>Som regel skickas intyget till beställarens folkbokföringsadress. Om du behöver det skickat till en annan adress, till exempel om du tillfälligt befinner dig på annan ort, kan du framföra det vid telefonbeställning eller servicekontorets besök. Via den digitala tjänsten på Mina sidor är möjligheten till alternativ adress mer begränsad.</p>
+
+      <h3>Kostar det något att beställa flera exemplar?</h3>
+      <p>Nej. Varje beställning är gratis, och du kan beställa flera gånger om du behöver färska intyg till olika motparter. Det är inte ovanligt att behöva beställa om om ett tidigare intyg har blivit för gammalt eller om processen dragit ut på tiden.</p>
+
+      <h3>Räcker dödsfallsintyget för att hantera skulder i dödsboet?</h3>
+      <p>Dödsfallsintyget visar att personen är borta och identifierar dödsbodelägarna, men det är bouppteckningen och eventuell boutredning som formellt hanterar skulder och fordringar. Mer om det hittar du i vår guide om <a href="./dodsbo-skulder.html">dödsbo och skulder</a> samt vår <a href="./checklista-dodsbo.html">dödsbo-checklista</a>.</p>
+
+      <div class="seo-cta">
+        <p>Få en personlig checklista med alla praktiska steg efter dödsfallet — inklusive beställning av dödsfallsintyg och tidsfrister</p>
+        <a href="/" class="btn-primary">Skapa din Efterplan gratis →</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="seo-footer">
+    <p>© 2026 Efterplan · <a href="/">Tillbaka till appen</a> · <a href="/om.html">Om Efterplan</a> · Ej juridisk rådgivning</p>
+    <p class="seo-footer-links">
+      <a href="./bouppteckning-guide.html">Bouppteckning guide</a> &nbsp;·&nbsp;
+      <a href="./arvskifte-guide.html">Arvskifte guide</a> &nbsp;·&nbsp;
+      <a href="./laglott.html">Laglott</a> &nbsp;·&nbsp;
+      <a href="./saga-upp-hyresratt-dodsbo.html">Säga upp hyresrätt dödsbo</a> &nbsp;·&nbsp;
+      <a href="./salja-dodsbo.html">Sälja dödsbo</a> &nbsp;·&nbsp;
+      <a href="./dodsbo-skulder.html">Dödsbo skulder</a> &nbsp;·&nbsp;
+      <a href="./sarkullbarn.html">Särkullbarn</a> &nbsp;·&nbsp;
+      <a href="./sambo-arv.html">Sambo och arv</a> &nbsp;·&nbsp;
+      <a href="./testamente-guide.html">Testamente guide</a> &nbsp;·&nbsp;
+      <a href="./checklista-dodsbo.html">Checklista dödsbo</a>
+    </p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Ändringar

- **dodsfallsintyg.html** — ny SEO-sida (1 379 ord). Täcker vad ett dödsfallsintyg är, skillnaden mot dödsfallsintyg med släktutredning, vem som kan beställa, steg-för-steg-beställning (webb/telefon/kontor), användningsområden (bank, försäkring, hyresvärd, FK, PM), giltighetstid och skillnad mot bouppteckning.

Schema: Article + HowTo (4 steg) + FAQPage (5 frågor) + BreadcrumbList.

Interna länkar till: `saga-upp-hyresratt-dodsbo.html`, `bouppteckning-guide.html`, `arvskifte-guide.html`, `dodsbo-skulder.html`, `checklista-dodsbo.html`.

Sitemap.xml behövde inte uppdateras — `dodsfallsintyg.html` lades till i T090-T091-PR:en.