### PR TITLE
chore: ignorera lokala auto-genererade filer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules/
 .env.local
 .vercel
 .env*.local
+
+# Lokala auto-genererade filer (Cowork / checkmail-skill)
+*.skill
+cowork-veckorapport-*.md


### PR DESCRIPTION
## Summary
- Lägger till `*.skill` och `cowork-veckorapport-*.md` i `.gitignore`
- Filerna genereras lokalt (Cowork-rapporter, checkmail-skill) och ska inte tracka:as i repot

## Test plan
- [x] `git status` visar inte längre `checkmail.skill` eller `cowork-veckorapport-2026-05-11.md` som otrackade efter merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)