### PR TITLE
Tech tickets cleanup 2026-05-29: T103/T104/T106/T116/T117/T119/T120/T121

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,7 +76,7 @@ async function handlePremiumReturn() {
     const data = await r.json();
     if (data && data.ok) {
       setPremium(data.email || '');
-      track('Premium Activated');
+      track('premium_activated');
       alert('Tack! Premium är upplåst på den här enheten.');
     } else {
       alert('Vi kunde inte bekräfta betalningen direkt. Försök ladda om sidan om en stund.');
@@ -349,7 +349,7 @@ function updateCheckboxState(key) {
   document.querySelectorAll('#ob-step-2 input[type="checkbox"]').forEach(cb => {
     state[cb.dataset.key] = cb.checked;
   });
-  if (key) track('Checkbox Toggle', { key });
+  if (key) track('checkbox_toggle', { key });
 }
 
 function generatePlan() {
@@ -865,7 +865,7 @@ const saveTaskNote = _debounce(function(taskId, value) {
   notes[taskId] = value;
   try { localStorage.setItem('efterplan_notes', JSON.stringify(notes)); } catch(e) {}
   try { window.dispatchEvent(new Event('efterplan:state-changed')); } catch(e) {}
-  if (value.length > 0) track('Note Saved', { task: taskId });
+  if (value.length > 0) track('note_saved', { task: taskId });
 }, 400);
 
 function getTaskNote(taskId) {
@@ -996,7 +996,7 @@ function buildPreviewCTACard() {
 }
 
 function handlePreviewCTA() {
-  track('Preview CTA Clicked');
+  track('preview_cta_clicked');
   handlePaywallCTA();
 }
 
@@ -1336,7 +1336,7 @@ function submitBill() {
   saveBills();
   renderBills();
   hideBillForm();
-  track('Bill Added');
+  track('bill_added');
 }
 function toggleBillPaid(id) {
   if (!isOwnerMode()) return;
@@ -1440,10 +1440,10 @@ async function handleBillScan(event) {
       if (qr.due) document.getElementById('bill-amount-input').value = String(qr.due);
       if (qr.iref && form) form.dataset.ocr = String(qr.iref);
       setBillScanStatus('Hittade fakturadata — kontrollera och spara.');
-      track('Bill Scanned QR');
+      track('bill_scanned_qr');
     } else {
       setBillScanStatus('Foto sparat. Skriv beskrivning manuellt.');
-      track('Bill Scanned Photo Only');
+      track('bill_scanned_photo_only');
     }
     setTimeout(() => setBillScanStatus(''), 5000);
   } catch (err) {
@@ -2052,7 +2052,7 @@ function _doGenerateBulk(sender, email, genBtn) {
   document.querySelectorAll('.doc-form').forEach(f => f.classList.add('hidden'));
   document.getElementById('doc-result-bulk').classList.remove('hidden');
   if (genBtn) { genBtn.disabled = false; genBtn.textContent = 'Skapa alla brev →'; }
-  track('Doc Generated', { title: 'Bulk uppsägning', count: String(services.length) });
+  track('doc_generated', { title: 'Bulk uppsägning', count: String(services.length) });
   window.scrollTo(0, 0);
 }
 
@@ -2206,7 +2206,7 @@ Sörjd och saknad.${ovrigtLine}`.trim());
 }
 
 function showDocResult(title, text, emailSubject) {
-  track('Doc Generated', { title: title.split(' — ')[0] });
+  track('doc_generated', { title: title.split(' — ')[0] });
   document.querySelectorAll('.doc-form').forEach(f => f.classList.add('hidden'));
   document.getElementById('doc-chooser').classList.add('hidden');
   document.getElementById('result-title').textContent = title;
@@ -2396,7 +2396,7 @@ function showCompletionOverlay() {
   const first = overlay.querySelector(FOCUSABLE);
   if (first) setTimeout(() => first.focus(), 50);
   overlay.addEventListener('keydown', _coEscHandler);
-  track('Plan Completed');
+  track('plan_completed');
 }
 
 function closeCompletionOverlay() {
@@ -2410,7 +2410,7 @@ function closeCompletionOverlay() {
 
 // ─── PDF / PRINT ─────────────────────────────
 function printPlan() {
-  track('Plan Printed');
+  track('plan_printed');
   window.print();
 }
 
@@ -2429,7 +2429,7 @@ function printPlan() {
 })();
 
 async function handlePaywallCTA() {
-  track('Paywall CTA Clicked');
+  track('paywall_cta_clicked');
   if (isPremium()) return;
   let email = '';
   let userId = '';
@@ -2509,7 +2509,7 @@ function applySharedSnapshot(detail) {
 
   document.body.classList.add(SHARED.mode === 'edit' ? 'shared-edit' : 'shared-read');
   showScreen('screen-plan');
-  track('Shared Plan Opened', { mode: SHARED.mode });
+  track('shared_plan_opened', { mode: SHARED.mode });
 }
 
 window.addEventListener('efterplan:shared-loaded', (e) => {

--- a/arvskifte-guide.html
+++ b/arvskifte-guide.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/arvskifte-guide.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -179,3 +179,4 @@
   </footer>
 </body>
 </html>
+

--- a/arvsskatt.html
+++ b/arvsskatt.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/arvsskatt.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -174,3 +174,4 @@
   </footer>
 </body>
 </html>
+

--- a/auth-modal.html
+++ b/auth-modal.html
@@ -16,21 +16,21 @@
       <p class="modal-sub">Logga in för att synka din plan mellan enheter. Vi skickar en engångslänk till din e-post — inget lösenord behövs.</p>
       <form id="auth-magic-form" autocomplete="on">
         <label for="auth-email" class="sr-only">E-postadress</label>
-        <input type="email" id="auth-email" name="email" required autocomplete="email" placeholder="din@epost.se" style="width:100%;padding:12px 14px;border:1px solid var(--border);border-radius:10px;font-size:1rem;margin-bottom:12px;">
-        <button type="submit" class="btn-primary" style="width:100%;">Skicka inloggningslänk</button>
+        <input type="email" id="auth-email" name="email" required autocomplete="email" placeholder="din@epost.se" class="u-width-full u-padding-12-14 u-border-1px-solid-ddd u-border-radius-10px u-margin-bottom-12px">
+        <button type="submit" class="btn-primary u-width-full">Skicka inloggningslänk</button>
       </form>
-      <p id="auth-status" class="modal-sub" style="margin-top:12px;min-height:1.2em;"></p>
+      <p id="auth-status" class="modal-sub u-margin-top-12px u-min-height-1-2em"></p>
     </div>
 
     <!-- Logged-in view -->
     <div id="auth-view-in" class="hidden">
       <p class="modal-sub">Inloggad som <strong id="auth-email-display"></strong>.</p>
-      <div style="padding:14px;background:var(--grey-bg,#f5f5f5);border-radius:12px;margin-bottom:16px;">
-        <div id="auth-progress" style="font-weight:600;">— av — steg klara</div>
-        <div id="auth-last-sync" class="modal-sub" style="margin:4px 0 0;">Senaste synk: —</div>
+      <div class="u-padding-12-14 u-background-f0f0f0 u-border-radius-10px u-margin-bottom-16px">
+        <div id="auth-progress" class="u-font-weight-600">— av — steg klara</div>
+        <div id="auth-last-sync" class="modal-sub u-margin-top-4px">Senaste synk: —</div>
       </div>
-      <button type="button" id="auth-sync-btn" class="btn-ghost btn-sm" style="width:100%;margin-bottom:8px;">Synka nu</button>
-      <button type="button" id="auth-signout-btn" class="btn-ghost btn-sm" style="width:100%;">Logga ut</button>
+      <button type="button" id="auth-sync-btn" class="btn-ghost btn-sm u-width-full u-margin-bottom-8px">Synka nu</button>
+      <button type="button" id="auth-signout-btn" class="btn-ghost btn-sm u-width-full">Logga ut</button>
     </div>
   </div>
 </div>
@@ -126,3 +126,4 @@
   }
 })();
 </script>
+

--- a/bankkonto-dodsfall.html
+++ b/bankkonto-dodsfall.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/bankkonto-dodsfall.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -196,3 +196,4 @@
   </footer>
 </body>
 </html>
+

--- a/begravning-utomlands.html
+++ b/begravning-utomlands.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/begravning-utomlands.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -121,19 +121,19 @@
 
       <h2>Kostnader och försäkring</h2>
 
-      <table style="width:100%; border-collapse:collapse; margin:1em 0;">
+      <table class="u-width-full u-border-collapse u-margin-1em-0">
         <thead>
-          <tr style="background:#f0f0f0;">
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Åtgärd</th>
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Ungefärlig kostnad</th>
+          <tr class="u-background-f0f0f0">
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Åtgärd</th>
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Ungefärlig kostnad</th>
           </tr>
         </thead>
         <tbody>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Hemtransport kista, Europa</td><td style="padding:8px; border:1px solid #ddd;">20 000–40 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Hemtransport kista, interkontinental</td><td style="padding:8px; border:1px solid #ddd;">40 000–80 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Kremering utomlands + urna hem</td><td style="padding:8px; border:1px solid #ddd;">5 000–20 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Lokal begravning i utlandet</td><td style="padding:8px; border:1px solid #ddd;">15 000–50 000 kr (varierar kraftigt)</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Ambassädlegalisering av dokument</td><td style="padding:8px; border:1px solid #ddd;">500–2 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Hemtransport kista, Europa</td><td class="u-padding-8 u-border-1px-solid-ddd">20 000–40 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Hemtransport kista, interkontinental</td><td class="u-padding-8 u-border-1px-solid-ddd">40 000–80 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Kremering utomlands + urna hem</td><td class="u-padding-8 u-border-1px-solid-ddd">5 000–20 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Lokal begravning i utlandet</td><td class="u-padding-8 u-border-1px-solid-ddd">15 000–50 000 kr (varierar kraftigt)</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Ambassädlegalisering av dokument</td><td class="u-padding-8 u-border-1px-solid-ddd">500–2 000 kr</td></tr>
         </tbody>
       </table>
 
@@ -190,3 +190,4 @@
   </footer>
 </body>
 </html>
+

--- a/begravningsbyra.html
+++ b/begravningsbyra.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/begravningsbyra.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -103,22 +103,22 @@
       <h2>Vad kostar en begravningsbyrå?</h2>
       <p>Kostnadsstrukturen är viktig att förstå — byrån tar ett <strong>arvode</strong> för sin tid och koordinering, men de flesta stora kostnader är kopplade till dina val av kista, blommor, ceremoniplats och minnesstund.</p>
 
-      <table style="width:100%; border-collapse:collapse; margin:1em 0;">
+      <table class="u-width-full u-border-collapse u-margin-1em-0">
         <thead>
-          <tr style="background:#f0f0f0;">
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Post</th>
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Ungefärlig kostnad</th>
+          <tr class="u-background-f0f0f0">
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Post</th>
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Ungefärlig kostnad</th>
           </tr>
         </thead>
         <tbody>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Byråns grundarvode (planering, koordinering)</td><td style="padding:8px; border:1px solid #ddd;">8 000–20 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Kista (enkel till avancerad)</td><td style="padding:8px; border:1px solid #ddd;">2 000–30 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Kremation (ingår i krematoriumavgift)</td><td style="padding:8px; border:1px solid #ddd;">3 000–8 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Kyrkogårdsavgift / gravplats</td><td style="padding:8px; border:1px solid #ddd;">0–15 000 kr (ingår delvis i begravningsavgiften)</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Blommor och kransar</td><td style="padding:8px; border:1px solid #ddd;">3 000–10 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Minnesund med mat och lokal</td><td style="padding:8px; border:1px solid #ddd;">5 000–20 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Gravsten</td><td style="padding:8px; border:1px solid #ddd;">8 000–25 000 kr (beställs separat, ofta senare)</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;"><strong>Total, typisk begravning</strong></td><td style="padding:8px; border:1px solid #ddd;"><strong>30 000–80 000 kr</strong></td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Byråns grundarvode (planering, koordinering)</td><td class="u-padding-8 u-border-1px-solid-ddd">8 000–20 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Kista (enkel till avancerad)</td><td class="u-padding-8 u-border-1px-solid-ddd">2 000–30 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Kremation (ingår i krematoriumavgift)</td><td class="u-padding-8 u-border-1px-solid-ddd">3 000–8 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Kyrkogårdsavgift / gravplats</td><td class="u-padding-8 u-border-1px-solid-ddd">0–15 000 kr (ingår delvis i begravningsavgiften)</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Blommor och kransar</td><td class="u-padding-8 u-border-1px-solid-ddd">3 000–10 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Minnesund med mat och lokal</td><td class="u-padding-8 u-border-1px-solid-ddd">5 000–20 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Gravsten</td><td class="u-padding-8 u-border-1px-solid-ddd">8 000–25 000 kr (beställs separat, ofta senare)</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd"><strong>Total, typisk begravning</strong></td><td class="u-padding-8 u-border-1px-solid-ddd"><strong>30 000–80 000 kr</strong></td></tr>
         </tbody>
       </table>
 
@@ -200,3 +200,4 @@
   </footer>
 </body>
 </html>
+

--- a/bouppteckning-guide.html
+++ b/bouppteckning-guide.html
@@ -18,7 +18,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -194,3 +194,4 @@
   </footer>
 </body>
 </html>
+

--- a/bouppteckning-tidslinje.html
+++ b/bouppteckning-tidslinje.html
@@ -12,7 +12,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <link rel="icon" type="image/png" href="/favicon.png" />
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -330,3 +330,4 @@
   </footer>
 </body>
 </html>
+

--- a/boutredningsman.html
+++ b/boutredningsman.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/boutredningsman.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -120,17 +120,17 @@
       <h2>Vad kostar en boutredningsman?</h2>
       <p>Boutredningsmannen har rätt till skäligt arvode, beräknat på nedlagd tid. Arvodet tas ur dödsboets tillgångar och är prioriterat — det betalas innan arvingarna får ut sitt arv.</p>
 
-      <table style="width:100%; border-collapse:collapse; margin:1em 0;">
+      <table class="u-width-full u-border-collapse u-margin-1em-0">
         <thead>
-          <tr style="background:#f0f0f0;">
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Situation</th>
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Ungefärligt arvode</th>
+          <tr class="u-background-f0f0f0">
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Situation</th>
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Ungefärligt arvode</th>
           </tr>
         </thead>
         <tbody>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Enkelt bo, snabb avveckling (5–20 timmar)</td><td style="padding:8px; border:1px solid #ddd;">10 000–40 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Normalt bo med fastighetsförsäljning (20–60 timmar)</td><td style="padding:8px; border:1px solid #ddd;">40 000–120 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Komplicerat bo med tvister (60+ timmar)</td><td style="padding:8px; border:1px solid #ddd;">120 000–400 000 kr+</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Enkelt bo, snabb avveckling (5–20 timmar)</td><td class="u-padding-8 u-border-1px-solid-ddd">10 000–40 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Normalt bo med fastighetsförsäljning (20–60 timmar)</td><td class="u-padding-8 u-border-1px-solid-ddd">40 000–120 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Komplicerat bo med tvister (60+ timmar)</td><td class="u-padding-8 u-border-1px-solid-ddd">120 000–400 000 kr+</td></tr>
         </tbody>
       </table>
 
@@ -198,3 +198,4 @@
   </footer>
 </body>
 </html>
+

--- a/checklista-dodsbo.html
+++ b/checklista-dodsbo.html
@@ -18,7 +18,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -192,3 +192,4 @@
   </footer>
 </body>
 </html>
+

--- a/digital-dodsbo.html
+++ b/digital-dodsbo.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/digital-dodsbo.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -188,3 +188,4 @@
   </footer>
 </body>
 </html>
+

--- a/dodsannons.html
+++ b/dodsannons.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/dodsannons.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -153,19 +153,19 @@
 
       <h2>Vad kostar en dödsannons?</h2>
 
-      <table style="width:100%; border-collapse:collapse; margin:1em 0;">
+      <table class="u-width-full u-border-collapse u-margin-1em-0">
         <thead>
-          <tr style="background:#f0f0f0;">
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Kanal</th>
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Ungefärlig kostnad</th>
+          <tr class="u-background-f0f0f0">
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Kanal</th>
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Ungefärlig kostnad</th>
           </tr>
         </thead>
         <tbody>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Lokaltidning, liten annons</td><td style="padding:8px; border:1px solid #ddd;">500–1 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Lokaltidning, med foto</td><td style="padding:8px; border:1px solid #ddd;">1 000–2 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">DN / SvD</td><td style="padding:8px; border:1px solid #ddd;">1 500–3 500 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Digital minnessida</td><td style="padding:8px; border:1px solid #ddd;">Gratis</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Efterplans dödsannonsgenerator</td><td style="padding:8px; border:1px solid #ddd;">Gratis</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Lokaltidning, liten annons</td><td class="u-padding-8 u-border-1px-solid-ddd">500–1 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Lokaltidning, med foto</td><td class="u-padding-8 u-border-1px-solid-ddd">1 000–2 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">DN / SvD</td><td class="u-padding-8 u-border-1px-solid-ddd">1 500–3 500 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Digital minnessida</td><td class="u-padding-8 u-border-1px-solid-ddd">Gratis</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Efterplans dödsannonsgenerator</td><td class="u-padding-8 u-border-1px-solid-ddd">Gratis</td></tr>
         </tbody>
       </table>
 
@@ -212,3 +212,4 @@
   </footer>
 </body>
 </html>
+

--- a/dodsbo-auktion.html
+++ b/dodsbo-auktion.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/dodsbo-auktion.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -113,20 +113,20 @@
       <h2>Provision — vad kostar det?</h2>
       <p>Auktionshus tar provision från <em>både</em> säljare och köpare:</p>
 
-      <table style="width:100%; border-collapse:collapse; margin:1em 0;">
+      <table class="u-width-full u-border-collapse u-margin-1em-0">
         <thead>
-          <tr style="background:#f0f0f0;">
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Auktionshus / plattform</th>
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Säljarprovisionen</th>
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Köparpåslag</th>
+          <tr class="u-background-f0f0f0">
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Auktionshus / plattform</th>
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Säljarprovisionen</th>
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Köparpåslag</th>
           </tr>
         </thead>
         <tbody>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Bukowskis</td><td style="padding:8px; border:1px solid #ddd;">15–20 %</td><td style="padding:8px; border:1px solid #ddd;">20–25 %</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Stockholms Auktionsverk</td><td style="padding:8px; border:1px solid #ddd;">15–20 %</td><td style="padding:8px; border:1px solid #ddd;">20 %</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Auctionet.se</td><td style="padding:8px; border:1px solid #ddd;">0–15 %</td><td style="padding:8px; border:1px solid #ddd;">18–22 %</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Lokala auktionshus</td><td style="padding:8px; border:1px solid #ddd;">15–25 %</td><td style="padding:8px; border:1px solid #ddd;">15–25 %</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Tradera (privat)</td><td style="padding:8px; border:1px solid #ddd;">6–12 % (listningsavgift)</td><td style="padding:8px; border:1px solid #ddd;">0 %</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Bukowskis</td><td class="u-padding-8 u-border-1px-solid-ddd">15–20 %</td><td class="u-padding-8 u-border-1px-solid-ddd">20–25 %</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Stockholms Auktionsverk</td><td class="u-padding-8 u-border-1px-solid-ddd">15–20 %</td><td class="u-padding-8 u-border-1px-solid-ddd">20 %</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Auctionet.se</td><td class="u-padding-8 u-border-1px-solid-ddd">0–15 %</td><td class="u-padding-8 u-border-1px-solid-ddd">18–22 %</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Lokala auktionshus</td><td class="u-padding-8 u-border-1px-solid-ddd">15–25 %</td><td class="u-padding-8 u-border-1px-solid-ddd">15–25 %</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Tradera (privat)</td><td class="u-padding-8 u-border-1px-solid-ddd">6–12 % (listningsavgift)</td><td class="u-padding-8 u-border-1px-solid-ddd">0 %</td></tr>
         </tbody>
       </table>
 
@@ -211,3 +211,4 @@
   </footer>
 </body>
 </html>
+

--- a/dodsbo-bil.html
+++ b/dodsbo-bil.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/dodsbo-bil.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -179,3 +179,4 @@
   </footer>
 </body>
 </html>
+

--- a/dodsbo-bostadsratt.html
+++ b/dodsbo-bostadsratt.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/dodsbo-bostadsratt.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -162,3 +162,4 @@
   </footer>
 </body>
 </html>
+

--- a/dodsbo-checklista-7-dagar.html
+++ b/dodsbo-checklista-7-dagar.html
@@ -18,7 +18,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -177,3 +177,4 @@
   </footer>
 </body>
 </html>
+

--- a/dodsbo-deklaration.html
+++ b/dodsbo-deklaration.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/dodsbo-deklaration.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -179,3 +179,4 @@
   </footer>
 </body>
 </html>
+

--- a/dodsbo-fastighet.html
+++ b/dodsbo-fastighet.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/dodsbo-fastighet.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -196,3 +196,4 @@
   </footer>
 </body>
 </html>
+

--- a/dodsbo-skulder.html
+++ b/dodsbo-skulder.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/dodsbo-skulder.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -184,3 +184,4 @@
   </footer>
 </body>
 </html>
+

--- a/dodsfallsintyg.html
+++ b/dodsfallsintyg.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/dodsfallsintyg.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -231,3 +231,4 @@
   </footer>
 </body>
 </html>
+

--- a/efterlevandepension.html
+++ b/efterlevandepension.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/efterlevandepension.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -188,3 +188,4 @@
   </footer>
 </body>
 </html>
+

--- a/fullmakt-dodsbo.html
+++ b/fullmakt-dodsbo.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/fullmakt-dodsbo.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -169,3 +169,4 @@
   </footer>
 </body>
 </html>
+

--- a/ga4-dashboard/package-lock.json
+++ b/ga4-dashboard/package-lock.json
@@ -864,9 +864,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/ga4-dashboard/package.json
+++ b/ga4-dashboard/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "efterplan-ga4-dashboard",
   "version": "1.0.0",
   "private": true,

--- a/gravsten.html
+++ b/gravsten.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/gravsten.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -90,20 +90,20 @@
       <h2>Vad kostar en gravsten?</h2>
       <p>Priset varierar kraftigt beroende på material, storlek och gravyr. Här är en ungefärlig prisöversikt:</p>
 
-      <table style="width:100%; border-collapse:collapse; margin:1em 0;">
+      <table class="u-width-full u-border-collapse u-margin-1em-0">
         <thead>
-          <tr style="background:#f0f0f0;">
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Typ</th>
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Ungefärligt pris</th>
+          <tr class="u-background-f0f0f0">
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Typ</th>
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Ungefärligt pris</th>
           </tr>
         </thead>
         <tbody>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Enkel granitssten, standardmått</td><td style="padding:8px; border:1px solid #ddd;">8 000–12 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Granit med specialgravyr</td><td style="padding:8px; border:1px solid #ddd;">12 000–20 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Kalksten eller marmor</td><td style="padding:8px; border:1px solid #ddd;">15 000–30 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Sten med fotogravyr</td><td style="padding:8px; border:1px solid #ddd;">18 000–35 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Stor familjesten</td><td style="padding:8px; border:1px solid #ddd;">25 000–60 000 kr</td></tr>
-          <tr><td style="padding:8px; border:1px solid #ddd;">Träkors (tillfällig)</td><td style="padding:8px; border:1px solid #ddd;">500–2 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Enkel granitssten, standardmått</td><td class="u-padding-8 u-border-1px-solid-ddd">8 000–12 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Granit med specialgravyr</td><td class="u-padding-8 u-border-1px-solid-ddd">12 000–20 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Kalksten eller marmor</td><td class="u-padding-8 u-border-1px-solid-ddd">15 000–30 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Sten med fotogravyr</td><td class="u-padding-8 u-border-1px-solid-ddd">18 000–35 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Stor familjesten</td><td class="u-padding-8 u-border-1px-solid-ddd">25 000–60 000 kr</td></tr>
+          <tr><td class="u-padding-8 u-border-1px-solid-ddd">Träkors (tillfällig)</td><td class="u-padding-8 u-border-1px-solid-ddd">500–2 000 kr</td></tr>
         </tbody>
       </table>
 
@@ -200,3 +200,4 @@
   </footer>
 </body>
 </html>
+

--- a/index.html
+++ b/index.html
@@ -155,8 +155,8 @@
   <div class="landing-hero">
     <div class="landing-content">
       <p class="landing-brand">Efterplan</p>
-      <h1 class="landing-eyebrow">Det är mycket på en gång just nu.</h1>
-      <h2 class="landing-headline">Du behöver inte hålla reda på allt själv. Vi reder ut det praktiska — bank, bouppteckning, hyresrätt, papper — så att du kan ta det i din takt.</h2>
+      <p class="landing-eyebrow">Det är mycket på en gång just nu.</p>
+      <h1 class="landing-headline">Du behöver inte hålla reda på allt själv. Vi reder ut det praktiska — bank, bouppteckning, hyresrätt, papper — så att du kan ta det i din takt.</h1>
       <ul class="landing-payoff">
         <li>Inga formulär, ingen registrering</li>
         <li>Bara det som faktiskt är ditt att göra</li>
@@ -273,7 +273,7 @@
   <div class="ob-topbar">
     <button class="ob-back" id="ob-back-btn" onclick="obBack()">← Tillbaka</button>
     <div class="ob-dots" id="ob-dots"></div>
-    <div style="width:80px"></div>
+    <div class="u-width-80px"></div>
   </div>
 
   <div class="ob-stage" id="ob-stage">
@@ -474,7 +474,7 @@
   <div class="plan-tab-content active" id="tabcontent-plan">
     <div class="plan-wrap">
       <div class="plan-header">
-        <h1 class="plan-title" id="plan-title">Din plan</h1>
+        <h2 class="plan-title" id="plan-title">Din plan</h2>
         <p class="plan-sub" id="plan-sub">Börja med det som känns minst tungt.</p>
         <p class="plan-dodsbo-def" id="plan-dodsbo-def"></p>
         <div class="progress-bar-wrap" id="progress-bar-wrap" aria-hidden="true">
@@ -587,7 +587,7 @@
       <!-- Väljare -->
       <div id="doc-chooser">
         <div class="plan-header">
-          <h1 class="plan-title">Brev & dokument</h1>
+          <h2 class="plan-title">Brev & dokument</h2>
           <p class="plan-sub">Välj vad du behöver — vi skriver det åt dig.</p>
         </div>
         <button class="doc-bulk-cta" onclick="showDocForm('bulk')">
@@ -896,7 +896,7 @@
         <path class="co-check-mark" fill="none" d="M14 26l9 9 15-17"/>
       </svg>
     </div>
-    <h1 class="co-title" id="co-title">Allt är klart.</h1>
+    <h2 class="co-title" id="co-title">Allt är klart.</h2>
     <p class="co-name" id="co-name"></p>
     <p class="co-body">
       Det har tagit tid och kraft — men du har tagit dig igenom det.<br>
@@ -1076,7 +1076,7 @@
 
         <div class="share-active hidden" data-kind="read">
           <label class="sr-only" for="share-url-read">Läslänk</label>
-          <div style="display:flex;gap:8px;margin-bottom:8px;">
+          <div class="u-display-flex u-gap-8 u-margin-bottom-8px">
             <input type="text" id="share-url-read" class="share-url-input" data-kind="read" readonly style="flex:1;padding:12px 14px;border:1px solid var(--border);border-radius:10px;font-size:0.9rem;background:var(--grey-bg,#f5f5f5);">
             <button type="button" class="btn-ghost btn-sm share-copy-btn" data-kind="read">Kopiera</button>
           </div>
@@ -1097,7 +1097,7 @@
 
         <div class="share-active hidden" data-kind="edit">
           <label class="sr-only" for="share-url-edit">Redigeringslänk</label>
-          <div style="display:flex;gap:8px;margin-bottom:8px;">
+          <div class="u-display-flex u-gap-8 u-margin-bottom-8px">
             <input type="text" id="share-url-edit" class="share-url-input" data-kind="edit" readonly style="flex:1;padding:12px 14px;border:1px solid var(--border);border-radius:10px;font-size:0.9rem;background:var(--grey-bg,#f5f5f5);">
             <button type="button" class="btn-ghost btn-sm share-copy-btn" data-kind="edit">Kopiera</button>
           </div>

--- a/laglott.html
+++ b/laglott.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/laglott.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -190,3 +190,4 @@
   </footer>
 </body>
 </html>
+

--- a/om.html
+++ b/om.html
@@ -12,7 +12,7 @@
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <link rel="icon" type="image/png" href="/favicon.png" />
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -48,3 +48,4 @@
   </footer>
 </body>
 </html>
+

--- a/roadmap.md
+++ b/roadmap.md
@@ -256,8 +256,8 @@ Each step improves the product or the company in a meaningful way.
 | T100 | Meta description saknas i share-modal.html + auth-modal.html — false positive: filerna är body-fragment som inlines i index.html, meta-tagg ogiltig där | 2026-04-29 | Fas 12 | Veckorapport | 🟠 | SEO | x |
 | T101 | Standardisera GA4 event-namn till snake_case i app.js — `'Onboarding Start'` → `'onboarding_start'`, `'Plan Generated'` → `'plan_generated'`, `'Task Complete'` → `'task_completed'` (app.js rad 73, 170, 285, 1267). Dashboard server.js dual-querar gamla + nya namn så historisk data bevaras. | 2026-04-29 | Fas 12 | Veckorapport | 🟠 | Analytics | ✔ |
 | T102 | Uppgradera express 4→5 i ga4-dashboard/package.json + verifiera att inga breaking changes påverkar server.js. Express 5.2.1 installerat, smoke-test /api/health → 200 OK. | 2026-04-29 | Fas 12 | Veckorapport | 🟡 | Dev | ✔ |
-| T103 | Uppgradera googleapis 144→171 i ga4-dashboard/package.json (27 versioner efter, säkerhetsfixar + nya GA4-API-funktioner). Smoke-test `node server.js` + `/api/health` efter upgrade. | 2026-04-29 | Fas 12 | Veckorapport | 🟡 | Dev | ☐ |
-| T104 | Verifiera 4 moderate npm audit-sårbarheter i ga4-dashboard kvarstår efter T102 (express 4→5). Kör `npm audit` och `npm audit fix` om transitivt beroende. Inga critical/high — låg risk. | 2026-04-29 | Fas 12 | Veckorapport | 🟡 | Dev | ☐ |
+| T103 | Uppgradera googleapis 144→171 i ga4-dashboard/package.json. Verifierad 2026-05-29: package.json + lockfile båda på 171.4.0. | 2026-04-29 | Fas 12 | Veckorapport | 🟡 | Dev | ✔ |
+| T104 | Verifiera 4 moderate npm audit-sårbarheter i ga4-dashboard. Status 2026-05-29: 0 sårbarheter i root, 1 moderate kvar i ga4-dashboard (qs DoS, låg reell risk). qs 6.14.2→6.15.2 i lockfile. | 2026-04-29 | Fas 12 | Veckorapport | 🟡 | Dev | ✔ |
 
 ---
 
@@ -297,8 +297,8 @@ Each step improves the product or the company in a meaningful way.
 
 | ID | Task | Date | Phase | Source | Priority | Type | Status |
 |----|------|------|-------|--------|----------|------|--------|
-| T116 | UTF-8 BOM i ga4-dashboard/package.json — filen sparad med BOM (EF BB BF) vilket är ogiltigt JSON per RFC 8259. Python json-modulen kraschar med JSONDecodeError vid parsing (reproducerat i veckorapport-körning 2026-05-18). Ta bort BOM: `sed -i '1s/^\xEF\xBB\xBF//' ga4-dashboard/package.json` eller öppna i editor och spara som UTF-8 utan BOM. Fil: ga4-dashboard/package.json rad 1. | 2026-05-18 | Fas 12 | Veckorapport | 🟠 | Dev | ☐ |
-| T117 | Kvarvarande GA4-events i Title Case — 12 track()-anrop i app.js använder fortfarande Title Case och skapar inkonsistent GA4-data jämfört med core-events (T101 ✔). Berörda: 'Premium Activated' (r79), 'Checkbox Toggle' (r352), 'Note Saved' (r868), 'Preview CTA Clicked' (r999), 'Bill Added' (r1339), 'Bill Scanned QR' (r1443), 'Bill Scanned Photo Only' (r1446), 'Doc Generated' (r2055, r2209), 'Plan Completed' (r2399), 'Plan Printed' (r2413), 'Paywall CTA Clicked' (r2432), 'Shared Plan Opened' (r2512). Byt till snake_case. Fil: app.js. | 2026-05-18 | Fas 12 | Veckorapport | 🟡 | Analytics | ☐ |
+| T116 | UTF-8 BOM borttagen från ga4-dashboard/package.json (EF BB BF). Innehållet oförändrat. Åtgärdat 2026-05-29. | 2026-05-18 | Fas 12 | Veckorapport | 🟠 | Dev | ✔ |
+| T117 | 13 GA4-events i app.js bytta från Title Case till snake_case (premium_activated, checkbox_toggle, note_saved, preview_cta_clicked, bill_added, bill_scanned_qr, bill_scanned_photo_only, doc_generated x2, plan_completed, plan_printed, paywall_cta_clicked, shared_plan_opened). Dashboard server.js dual-querar gamla + nya namn (T101) så historisk data bevaras. Åtgärdat 2026-05-29. | 2026-05-18 | Fas 12 | Veckorapport | 🟡 | Analytics | ✔ |
 | T118 | Roadmap-status synkad: T106 (UptimeRobot) markerad ✔ — T111 ✔ bekräftar att UptimeRobot sattes upp 2026-05-11 men T106 stod kvar som ☐. Uppdaterat i detta commit. | 2026-05-18 | Fas 12 | Veckorapport | 🟡 | Dev | ✔ |
 
 ---
@@ -307,4 +307,15 @@ Each step improves the product or the company in a meaningful way.
 
 | ID | Task | Date | Phase | Source | Priority | Type | Status |
 |----|------|------|-------|--------|----------|------|--------|
-| T119 | om.html saknas i sitemap.xml — "Om Efterplan"-sidan har korrekt canonical (https://efterplan.se/om.html) och meta description men saknas helt i sitemap.xml (0 träffar). Sökmotorer prioriterar inte sidan för crawling. Lägg till `<url>`-block med `<loc>`, `<lastmod>` och `<changefreq>monthly</changefreq>` i sitemap.xml. Fil: sitemap.xml. | 2026-05-25 | Fas 12 | Veckorapport | 🟠 | SEO | ☐ |
+| T119 | om.html tillagd i sitemap.xml (priority 0.5, monthly). Sajten hade sidan men sitemap missade den. Åtgärdat 2026-05-29. | 2026-05-25 | Fas 12 | Veckorapport | 🟠 | SEO | ✔ |
+
+---
+
+# 🔍 VECKORAPPORT-TICKETS — 2026-05-29
+
+| ID | Task | Date | Phase | Source | Priority | Type | Status |
+|----|------|------|-------|--------|----------|------|--------|
+| T120 | Cache-busting förenat på 33 HTML-sidor: `style.css` → `style.css?v=3` (förut bara index.html versionerad). Eliminerar stale-CSS-risk efter deploy. | 2026-05-29 | Fas 12 | Dagsrapport | 🔴 | Dev | ✔ |
+| T121 | h1-hierarki: index.html har nu exakt en h1 (landing-headline). plan-title och co-title demoteras till h2; landing-eyebrow till p. Två trasiga slut-taggar i WIP rättade samtidigt. | 2026-05-29 | Fas 12 | Dagsrapport | 🟠 | A11y | ✔ |
+| T122 | Tokenisera 135 hårdkodade hex-färger i inline `style=`. Inte påbörjat — kräver designpass mot `style-tokens.css`. | 2026-05-29 | Fas 12 | Dagsrapport | 🟡 | Design | ☐ |
+| T123 | De-inlining: utility-klasser (.u-*) tillagda i style.css och applicerade på auth-modal.html + vad-gora-nar-nagon-dor.html. ~50 nya utility-klasser. Återstår: rulla ut på övriga sidor med inline style=. | 2026-05-29 | Fas 12 | Dagsrapport | 🟢 | Dev | ⧖ |

--- a/saga-upp-hyresratt-dodsbo.html
+++ b/saga-upp-hyresratt-dodsbo.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/saga-upp-hyresratt-dodsbo.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -211,3 +211,4 @@
   </footer>
 </body>
 </html>
+

--- a/salja-dodsbo.html
+++ b/salja-dodsbo.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/salja-dodsbo.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -190,3 +190,4 @@
   </footer>
 </body>
 </html>
+

--- a/sambo-arv.html
+++ b/sambo-arv.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/sambo-arv.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -182,3 +182,4 @@
   </footer>
 </body>
 </html>
+

--- a/sarkullbarn.html
+++ b/sarkullbarn.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/sarkullbarn.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -185,3 +185,4 @@
   </footer>
 </body>
 </html>
+

--- a/share-modal.html
+++ b/share-modal.html
@@ -180,3 +180,4 @@
   refresh();
 })();
 </script>
+

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -192,4 +192,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://efterplan.se/om.html</loc>
+    <lastmod>2026-05-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>

--- a/style.css
+++ b/style.css
@@ -2893,3 +2893,51 @@ body.shared-edit #paywall-card { display: none !important; }
 }
 .landing-footer-links { font-size: 0.8rem; margin-top: 6px; opacity: 0.7; }
 .landing-footer-links a { color: inherit; }
+
+/* Utility classes for moved inline styles */
+.u-padding-8 { padding: 8px; }
+.u-border-1px-solid-ddd { border: 1px solid #ddd; }
+.u-width-full { width: 100%; }
+.u-text-left { text-align: left; }
+.u-padding-8-12 { padding: 8px 12px; }
+.u-margin-1em-0 { margin: 1em 0; }
+.u-margin-bottom-6px { margin-bottom: 6px; }
+.u-border-bottom-1px-solid-eee { border-bottom: 1px solid #eee; }
+.u-border-collapse { border-collapse: collapse; }
+.u-margin-bottom-28px { margin-bottom: 28px; }
+.u-background-f0f0f0 { background: #f0f0f0; }
+.u-margin-bottom-8px { margin-bottom: 8px; }
+.u-border-radius-10px { border-radius: 10px; }
+.u-padding-12-14 { padding: 12px 14px; }
+.u-min-height-1-2em { min-height: 1.2em; }
+.u-margin-top-8px { margin-top: 8px; }
+.u-display-flex { display: flex; }
+.u-flex-1 { flex: 1; }
+.u-margin-top-12px { margin-top: 12px; }
+.u-font-weight-600 { font-weight: 600; }
+.u-margin-top-4px { margin-top: 4px; }
+.u-margin-bottom-8px { margin-bottom: 8px; }
+.u-background-var-grey-bg { background: var(--grey-bg,#f5f5f5); }
+.u-width-80px { width: 80px; }
+.u-margin-top-12px { margin-top: 12px; }
+.u-margin-top-8px { margin-top: 8px; }
+.u-margin-bottom-6px { margin-bottom: 6px; }
+.u-margin-bottom-28px { margin-bottom: 28px; }
+.u-display-flex { display: flex; }
+.u-gap-8 { gap: 8px; }
+.u-margin-bottom-8px { margin-bottom: 8px; }
+.u-font-size-0-9rem { font-size: 0.9rem; }
+.u-border-var-border { border: 1px solid var(--border); }
+.u-font-size-0-9rem { font-size: 0.9rem; }
+.u-max-width-260px { max-width: 260px; }
+
+/* Utility classes for vad-gora-nar-nagon-dor.html */
+.u-font-size-0-95rem { font-size: 0.95rem; }
+.u-margin-1rem-0 { margin: 1rem 0; }
+.u-border-bottom-2px-solid-ddd { border-bottom: 2px solid #ddd; }
+.u-background-f0f4f8 { background: #f0f4f8; }
+.u-border-bottom-1px-solid-eee { border-bottom: 1px solid #eee; }
+.u-background-f0f4f8 { background: #f0f4f8; }
+.u-padding-8-12 { padding: 8px 12px; }
+.u-border-bottom-2px-solid-ddd { border-bottom: 2px solid #ddd; }
+.u-border-bottom-1px-solid-eee { border-bottom: 1px solid #eee; }

--- a/testamente-guide.html
+++ b/testamente-guide.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/testamente-guide.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -171,3 +171,4 @@
   </footer>
 </body>
 </html>
+

--- a/tomma-dodsbo.html
+++ b/tomma-dodsbo.html
@@ -18,7 +18,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -157,29 +157,29 @@
       <h2>Vad kostar en professionell dödsboröjning?</h2>
       <p>Många väljer att anlita ett professionellt dödsboröjningsföretag. Det sparar tid och kraft — och kan faktiskt bli billigare om firman köper värdefulla föremål.</p>
 
-      <table style="width:100%; border-collapse:collapse; margin:1em 0;">
+      <table class="u-width-full u-border-collapse u-margin-1em-0">
         <thead>
-          <tr style="background:#f0f0f0;">
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Bostadens storlek</th>
-            <th style="text-align:left; padding:8px; border:1px solid #ddd;">Ungefärlig kostnad</th>
+          <tr class="u-background-f0f0f0">
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Bostadens storlek</th>
+            <th class="u-text-left u-padding-8 u-border-1px-solid-ddd">Ungefärlig kostnad</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td style="padding:8px; border:1px solid #ddd;">Lägenhet 1–2 rum</td>
-            <td style="padding:8px; border:1px solid #ddd;">5 000–12 000 kr</td>
+            <td class="u-padding-8 u-border-1px-solid-ddd">Lägenhet 1–2 rum</td>
+            <td class="u-padding-8 u-border-1px-solid-ddd">5 000–12 000 kr</td>
           </tr>
           <tr>
-            <td style="padding:8px; border:1px solid #ddd;">Lägenhet 3–4 rum</td>
-            <td style="padding:8px; border:1px solid #ddd;">10 000–20 000 kr</td>
+            <td class="u-padding-8 u-border-1px-solid-ddd">Lägenhet 3–4 rum</td>
+            <td class="u-padding-8 u-border-1px-solid-ddd">10 000–20 000 kr</td>
           </tr>
           <tr>
-            <td style="padding:8px; border:1px solid #ddd;">Villa, litet</td>
-            <td style="padding:8px; border:1px solid #ddd;">15 000–30 000 kr</td>
+            <td class="u-padding-8 u-border-1px-solid-ddd">Villa, litet</td>
+            <td class="u-padding-8 u-border-1px-solid-ddd">15 000–30 000 kr</td>
           </tr>
           <tr>
-            <td style="padding:8px; border:1px solid #ddd;">Villa, stort / landtgård</td>
-            <td style="padding:8px; border:1px solid #ddd;">30 000–80 000 kr</td>
+            <td class="u-padding-8 u-border-1px-solid-ddd">Villa, stort / landtgård</td>
+            <td class="u-padding-8 u-border-1px-solid-ddd">30 000–80 000 kr</td>
           </tr>
         </tbody>
       </table>
@@ -258,3 +258,4 @@
   </footer>
 </body>
 </html>
+

--- a/vad-gora-nar-nagon-dor.html
+++ b/vad-gora-nar-nagon-dor.html
@@ -12,7 +12,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <link rel="icon" type="image/png" href="/favicon.png" />
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -153,10 +153,10 @@
 
       <table style="width:100%;border-collapse:collapse;font-size:0.95rem;margin:1rem 0">
         <thead>
-          <tr style="background:#f0f4f8">
-            <th style="text-align:left;padding:8px 12px;border-bottom:2px solid #ddd">Uppgift</th>
-            <th style="text-align:left;padding:8px 12px;border-bottom:2px solid #ddd">Kontakt</th>
-            <th style="text-align:left;padding:8px 12px;border-bottom:2px solid #ddd">När</th>
+          <tr class="u-background-f0f4f8">
+            <th class="u-text-left u-padding-8-12 u-border-bottom-2px-solid-ddd">Uppgift</th>
+            <th class="u-text-left u-padding-8-12 u-border-bottom-2px-solid-ddd">Kontakt</th>
+            <th class="u-text-left u-padding-8-12 u-border-bottom-2px-solid-ddd">När</th>
           </tr>
         </thead>
         <tbody>
@@ -198,3 +198,5 @@
   </footer>
 </body>
 </html>
+
+

--- a/vad-kostar-en-begravning.html
+++ b/vad-kostar-en-begravning.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/vad-kostar-en-begravning.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="stylesheet" href="style-tokens.css?v=5">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T1T40TYPQB"></script>
@@ -179,3 +179,4 @@
   </footer>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- **T120** Enhetlig cache-busting `style.css?v=3` på 33 HTML-sidor (eliminerar stale-CSS-risk efter deploy)
- **T121** En h1 per vy i index.html — `landing-headline` befordrad till h1, övriga demoteras till h2/p. Trasiga slut-taggar (`</h1>` på p/h2) och fyra dubblerade `class=`-attribut i auth-modal rättade
- **T117** 13 GA4-events i app.js bytta från Title Case till snake_case (dashboard server.js dual-querar gamla + nya namn via T101)
- **T116** UTF-8 BOM (EF BB BF) borttagen ur `ga4-dashboard/package.json`
- **T119** `om.html` tillagd i sitemap.xml (priority 0.5, monthly)
- **T123 (delvis)** Utility-klasser tillagda i style.css (~50 st) och applicerade på auth-modal.html + vad-gora-nar-nagon-dor.html
- **T104** qs 6.14.2→6.15.2 i ga4-dashboard lockfile (säkerhetsfix)
- **Roadmap-sync** T103/T104/T106/T116/T117/T119/T120/T121 markerade ✔; T123 ⧖; T113 + T122 fortsatt öppna

## Test plan
- [ ] Smoke-test landing-vyn i webbläsare — exakt en h1 i DOM (`document.querySelectorAll('h1').length === 1`)
- [ ] Verifiera att style.css renderas (no FOUC, ingen 404 på `?v=3`)
- [ ] Öppna auth-modal — alla utility-klasser appliceras (knappar full width, marginaler stämmer)
- [ ] Trigger ett par GA4-events (klicka "Börja här", slutför ett task) — verifiera snake_case-namn i GA4 DebugView
- [ ] `node ga4-dashboard/server.js` startar utan BOM-relaterat JSON-fel
- [ ] `xmllint --noout sitemap.xml` passerar; om.html syns i sitemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)