### PR TITLE
Koppla "Hitta viktiga dokument" till Arkiv-fliken

### DIFF
--- a/app.js
+++ b/app.js
@@ -1106,6 +1106,13 @@ function renderTaskList(containerId, tasks, nextTaskId, globalOffset = 0) {
       ? `<button class="task-expand-doc" onclick="event.stopPropagation();switchTab('docs');showDocForm('${task.hasDoc}')">Generera dokument →</button>`
       : '';
 
+    // "Hitta viktiga dokument" ber användaren samla ihop papper men saknade
+    // en väg vidare till Arkiv-fliken (foto + AI-kategorisering, T143–T148)
+    // där de faktiskt kan sparas. Kopplar ihop dem.
+    const arkivLinkHtml = task.id === 'viktiga_dokument'
+      ? `<button class="task-expand-doc" onclick="event.stopPropagation();switchTab('arkiv')">📷 Fota och spara dokumenten →</button>`
+      : '';
+
     const doneHtml = task.done
       ? `<span class="task-expand-done">Klar ✓</span>
          <button class="task-expand-undo-btn" onclick="event.stopPropagation();undoTaskDoneManual('${task.id}')">Markera som ej klar</button>`
@@ -1143,6 +1150,7 @@ function renderTaskList(containerId, tasks, nextTaskId, globalOffset = 0) {
         <div class="task-expand-actions">
           ${doneHtml}
           ${docHtml}
+          ${arkivLinkHtml}
         </div>
       </div>
     `;


### PR DESCRIPTION
## Bakgrund

Checklistans allra första uppgift, **"Hitta viktiga dokument"** (`viktiga_dokument`, den första i `TASK_LIBRARY`), ber användaren samla ihop dödsfallsintyg, testamente, försäkringsbrev m.m. — men hade ingen koppling vidare till **🗂 Arkiv**-fliken (foto + AI-kategorisering, T143–T148, T162) längst ner i tab-baren, där dokumenten faktiskt kan fotograferas och sparas. Funktionen fanns och fungerade, men syntes ingenstans från det naturliga första steget i flödet.

Andra uppgifter med ett kopplat dokument (fullmakt, bank, försäkring) har redan en "Generera dokument →"-knapp som hoppar till Dokument-fliken (`task.hasDoc`). "Hitta viktiga dokument" saknade motsvarande koppling till Arkiv-fliken.

## Ändring

`app.js` — lade till en `📷 Fota och spara dokumenten →`-knapp specifikt på `viktiga_dokument`-uppgiften, samma knappstil/mönster som de befintliga dokument-knapparna, men länkar till `switchTab('arkiv')` istället för `docs`.

## Test plan

- [x] `node --check app.js` — syntax OK
- [ ] Öppna appen, skapa en plan, expandera första uppgiften ("Hitta viktiga dokument") — ny knapp "📷 Fota och spara dokumenten →" syns i åtgärdsraden
- [ ] Klicka knappen — hoppar till 🗂 Arkiv-fliken

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFhgrK7K8hsqEXr4KxBMda)_