### PR TITLE
Google Ads: konverteringsspårning (Alternativ B) — byggd, avstängd

### DIFF
--- a/ADS-SETUP.md
+++ b/ADS-SETUP.md
@@ -1,0 +1,77 @@
+# Google Ads — konverteringsspårning (aktivering)
+
+Koden är på plats (`app.js`, PR från branch `ads-conversion-tracking`).
+Den är **avstängd tills du fyllt i tre värden**. Fram till dess laddas
+ingen Google-kod och inga mätcookies sätts.
+
+Kampanjunderlaget (annonsgrupper, sökord, budget): `google-ads-underlag-2026-08.md`.
+
+---
+
+## Vad du gör i Google Ads (engångs)
+
+1. **Verktyg → Konverteringar → + Ny konverteringsåtgärd → Webbplats**.
+2. Skapa **två** åtgärder:
+
+   | Namn | Kategori | Värde | Räkning | Används för |
+   |------|----------|-------|---------|-------------|
+   | `Personlig plan skapad` | Skicka in leadformulär (eller "Övrigt") | Inget värde | En | mjuk signal — någon gick igenom onboardingen och fick en plan |
+   | `Köp 49 kr` | Köp | **Använd olika värden** (skickas från koden) | En | hård signal — betalning genomförd |
+
+3. För varje åtgärd väljer du **"Använd Google-taggen"** (inte Google Tag Manager,
+   inte "importera från GA4" — GA4 finns inte längre).
+4. Google visar då ett **konverterings-ID** (`AW-XXXXXXXXXX`) och en
+   **konverteringsetikett** per åtgärd (`abCdEfGhIjKlMnOp`).
+   ID:t är samma för båda; etiketten är olika.
+
+## Vad du (eller Claude) fyller i
+
+I `app.js`, längst upp (sök på `ADS_CONVERSION_ID`):
+
+```js
+const ADS_CONVERSION_ID   = 'AW-XXXXXXXXXX';   // ditt konverterings-ID
+const ADS_LABEL_PLAN      = 'xxxxxxxxxxxxxxxx'; // etikett för "Personlig plan skapad"
+const ADS_LABEL_PURCHASE  = 'yyyyyyyyyyyyyyyy'; // etikett för "Köp 49 kr"
+```
+
+Bumpa `app.js?v=30` → `?v=31` i `index.html` och deploya. Klart.
+
+## Vad koden gör när det är ifyllt
+
+| Händelse | Var i koden | Konvertering |
+|----------|-------------|--------------|
+| Onboarding klar → plan visas | `generatePlan()` | `ADS_LABEL_PLAN` (mjuk, inget värde) |
+| Stripe-betalning bekräftad vid retur | `handlePremiumReturn()` | `ADS_LABEL_PURCHASE` med värde (49 kr, eller faktiskt `amount_total` från Stripe) och `transaction_id = Stripe-sessionen` → Google dedupar, en omladdning dubbelräknar inte |
+
+Dessutom, oberoende av om taggen är på: `gclid` och `utm_*` från
+annons-URL:en sparas i `localStorage` (`efterplan_gclid`, `efterplan_utm`)
+vid landning — underlag för **offline conversion import** (Stripe-webhook
+→ Ads) om du vill ha exakt CAC per sökord senare.
+
+## Annons-URL:er — UTM-tagga alltid
+
+Även med taggen på, sätt final URL i varje annons till t.ex.:
+
+```
+https://efterplan.se/arvskifte-mall.html?utm_source=google&utm_medium=cpc&utm_campaign=arvskifte&utm_term={keyword}&utm_content={creative}
+```
+
+`{keyword}` / `{creative}` är Google ValueTrack — fylls i automatiskt.
+Ger sökordsnivå i Plausible också.
+
+## Integritetsnotis
+
+När `ADS_CONVERSION_ID` är ifyllt sätter Google-taggen `_gcl_*`-cookies
+för den som klickat en annons. Det är en medveten avvikelse från
+"ingen Google-kod / sparas bara lokalt" (PR #85 tog bort GA4). Överväg
+att nämna det i `index.html` §"Din integritet" när du aktiverar, eller
+håll det avstängt och kör Plausible-only (Alternativ A i underlaget).
+
+## Efter 2 veckor
+
+- Ads → Sökord → kolumn **Konv.** och **Kostn./konv.**: pausa sökord med
+  0 konverteringar eller CPC > 10 kr.
+- Söktermsrapporten varje vecka → lägg irrelevanta som negativa sökord.
+- Transaktionsord ("arvskifte mall") utvärderas på **Kostn./konv. för Köp 49 kr**.
+- Informationsord ("vad gör man när någon dör") på **Kostn./konv. för plan skapad**
+  — och överväg att pausa dem om de bara dubblerar din gratis organiska trafik.

--- a/api/verify-checkout.js
+++ b/api/verify-checkout.js
@@ -43,7 +43,13 @@ export default async function handler(req, res) {
       console.warn('[verify-checkout] supabase upsert skipped', e?.message);
     }
 
-    return res.status(200).json({ ok: true, email, status: 'paid' });
+    return res.status(200).json({
+      ok: true,
+      email,
+      status: 'paid',
+      amount_total: session.amount_total ?? null, // öre — klienten skickar /100 till Google Ads
+      currency: session.currency || null,
+    });
   } catch (err) {
     console.error('[verify-checkout]', err);
     return res.status(500).json({ ok: false, error: 'verify_failed' });

--- a/app.js
+++ b/app.js
@@ -43,6 +43,63 @@ function isDocLocked(type) {
   return PAYWALL_ENABLED && !isPremium() && !FREE_DOC_TYPES.includes(type);
 }
 
+// ─── GOOGLE ADS — KONVERTERINGSSPÅRNING (opt-in) ─────────────
+// Fyll i värdena från Google Ads → Verktyg → Konverteringar (se ADS-SETUP.md).
+// Alla tre tomma = ingen Google-kod laddas, allt nedan blir no-op.
+// OBS: när ADS_CONVERSION_ID är ifyllt laddas Google-taggen och sätter
+// mätcookies (_gcl_*) för den som kommer via en annons. Detta är en
+// medveten avvikelse från "ingen Google-kod" (PR #85) — bara för
+// annonskonvertering, ingen GA4-analys.
+const ADS_CONVERSION_ID   = '';   // t.ex. 'AW-123456789'
+const ADS_LABEL_PLAN      = '';   // konv.etikett — "personlig plan skapad" (mjuk)
+const ADS_LABEL_PURCHASE  = '';   // konv.etikett — "49 kr-köp" (hård, med värde)
+
+// Fånga gclid + utm_* vid landning — för attribution och ev. offline
+// conversion import (Stripe → Ads) senare. Rent localStorage, ingen kod laddas.
+(function captureAdClick() {
+  try {
+    const p = new URLSearchParams(location.search);
+    const gclid = p.get('gclid');
+    if (gclid) {
+      localStorage.setItem('efterplan_gclid', JSON.stringify({ gclid, ts: Date.now() }));
+    }
+    const utm = {};
+    for (const k of ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content']) {
+      const v = p.get(k);
+      if (v) utm[k] = v;
+    }
+    if (Object.keys(utm).length) {
+      localStorage.setItem('efterplan_utm', JSON.stringify({ ...utm, ts: Date.now() }));
+    }
+  } catch (e) { /* private mode / storage disabled */ }
+})();
+
+// Ladda Google Ads-taggen — bara om ett konverterings-ID är konfigurerat.
+(function loadAdsTag() {
+  if (!ADS_CONVERSION_ID) return;
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = window.gtag || function () { window.dataLayer.push(arguments); };
+  window.gtag('js', new Date());
+  window.gtag('config', ADS_CONVERSION_ID);
+  const s = document.createElement('script');
+  s.async = true;
+  s.src = 'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent(ADS_CONVERSION_ID);
+  document.head.appendChild(s);
+})();
+
+// Fyr en Google Ads-konvertering. No-op om taggen inte är konfigurerad.
+function adsConversion(label, opts) {
+  opts = opts || {};
+  if (!ADS_CONVERSION_ID || !label || typeof window.gtag !== 'function') return;
+  const params = { send_to: ADS_CONVERSION_ID + '/' + label };
+  if (typeof opts.value === 'number' && opts.value > 0) {
+    params.value = opts.value;
+    params.currency = 'SEK';
+  }
+  if (opts.transactionId) params.transaction_id = String(opts.transactionId);
+  try { window.gtag('event', 'conversion', params); } catch (e) {}
+}
+
 function applyPremiumState() {
   const premium = isPremium();
   document.body.classList.toggle('is-premium', premium);
@@ -90,6 +147,10 @@ async function handlePremiumReturn() {
     if (data && data.ok) {
       setPremium(data.email || '');
       track('premium_activated');
+      // Hård konvertering — 49 kr-köp. transaction_id = Stripe-sessionen
+      // (Google Ads deduplicerar, så en omladdning dubbelräknar inte).
+      const kr = typeof data.amount_total === 'number' ? data.amount_total / 100 : 49;
+      adsConversion(ADS_LABEL_PURCHASE, { value: kr, transactionId: sessionId });
       showToast('Tack! Premium är upplåst på den här enheten.', 'success');
     } else {
       showToast('Vi kunde inte bekräfta betalningen direkt. Försök ladda om sidan om en stund.', 'error');
@@ -328,6 +389,7 @@ function generatePlan() {
   saveState();
   saveTaskState();
   track('plan_generated', { relation: state.relation || 'okänd', has_death_date: !!state.deathDate });
+  adsConversion(ADS_LABEL_PLAN); // mjuk konvertering — personlig plan skapad
   submitReminderOptinIfChecked();
   showScreen('screen-plan');
 }

--- a/google-ads-underlag-2026-08.md
+++ b/google-ads-underlag-2026-08.md
@@ -95,12 +95,17 @@ Byggt på riktig Search Console-data (90 dagar, hämtad 2026-08-15): snittpositi
 > konverteringar → ingen Smart Bidding, du optimerar manuellt på
 > CPC/CTR + Söktermsrapporten.
 >
-> **Alternativ B (rekommenderat om budget > någon tusenlapp/mån):** lägg
-> tillbaka **enbart** Google Ads konverteringstagg (`gtag.js` med ett
-> `AW-xxxxx`-ID, inte GA4:s `G-xxxxx`). Fyr en konvertering på
-> `plan_completed` (mjuk) och en på Stripe-tacksidan (49 kr, hård, med
-> värde). Då får du konverteringar + kostnad/konv. **per sökord** direkt
-> i Ads-tabellen och kan köra Smart Bidding.
+> **Alternativ B (rekommenderat om budget > någon tusenlapp/mån):**
+> **koden är redan byggd** (branch `ads-conversion-tracking`) — mjuk
+> konvertering fyr:s i `generatePlan()`, hård (49 kr, med värde,
+> `transaction_id` = Stripe-sessionen) i `handlePremiumReturn()`.
+> Aktiveras genom att fylla i tre värden i `app.js`
+> (`ADS_CONVERSION_ID` + två etiketter). **Fullständig instruktion:
+> `ADS-SETUP.md`.** Tills dess laddas ingen Google-kod. När det är på
+> får du konverteringar + kostnad/konv. **per sökord** i Ads-tabellen
+> och kan köra Smart Bidding (men taggen sätter `_gcl_*`-cookies).
+> `gclid`/`utm_*` sparas redan i `localStorage` vid landning oavsett,
+> som underlag för offline conversion import senare.
 
 **Utvärdering per sökord (gäller båda alternativen):**
 - Tighta annonsgrupper (1–3 sökord/grupp) mot **rätt landningssida** (inte

--- a/index.html
+++ b/index.html
@@ -1080,7 +1080,7 @@
 </div>
 
 <script src="supabase-client.js?v=3" defer></script>
-<script src="app.js?v=33" defer></script>
+<script src="app.js?v=34" defer></script>
 <script>
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => navigator.serviceWorker.register('./sw.js'));


### PR DESCRIPTION
Bygger på #85 (designgenomgången, som tog bort GA4/gtag). **Mergas efter #85.**

Återinför **enbart** en Google Ads-konverteringstagg — opt-in, avstängd som default. Ingen GA4-analys.

## Vad som är byggt (`app.js`)

- `ADS_CONVERSION_ID` + två etikett-konstanter högst upp. **Alla tre tomma = ingen Google-kod laddas, allt blir no-op.**
- `captureAdClick()` — `gclid` + `utm_*` från annons-URL:en sparas i `localStorage` vid landning (alltid, ren localStorage). Underlag för attribution och offline conversion import.
- `loadAdsTag()` — laddar `gtag.js` **bara** om `ADS_CONVERSION_ID` är ifyllt.
- `adsConversion(label, {value, transactionId})` — guardad no-op.
- **Mjuk konvertering** i `generatePlan()` — personlig plan skapad.
- **Hård konvertering** i `handlePremiumReturn()` — 49 kr-köp, värde från Stripe `amount_total/100` (fallback 49), `transaction_id = Stripe-sessionen` (Google dedupar → omladdning dubbelräknar inte).

`api/verify-checkout.js` returnerar nu `amount_total` + `currency`.

## Aktivering (kräver dig)

`ADS-SETUP.md` — exakt vad du gör i Google Ads-dashboarden (skapa två konverteringsåtgärder → få `AW-XXXXXXXXXX` + två etiketter) och var värdena klistras in. Tills dess laddas ingen kod.

## Integritetsnotis

När `ADS_CONVERSION_ID` fylls i sätter Google-taggen `_gcl_*`-cookies för den som kcommer via en annons — en medveten avvikelse från "ingen Google-kod" (#85). Överväg att nämna det i §"Din integritet" vid aktivering, eller kör Plausible-only (Alternativ A i `google-ads-underlag-2026-08.md`).

## Verifierat

Default av → ingen `gtag`, inga `googletagmanager`-requests, `gclid`/`utm` fångas i localStorage, `adsConversion` no-op:ar, hela onboarding→plan-flödet utan console-fel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
