### PR TITLE
Sätt max CPC 3 kr i Google Ads-underlaget

### DIFF
--- a/google-ads-underlag-2026-08.md
+++ b/google-ads-underlag-2026-08.md
@@ -11,6 +11,8 @@ Byggt på riktig Search Console-data (90 dagar, hämtad 2026-08-15): snittpositi
 ## Budget
 **Förslag: 75 kr/dag (~2 250 kr/månad), testperiod 2 veckor.** Lågkonkurrens-sökorden nedan har historiskt legat under 5 kr/klick i liknande nischer, så 75 kr/dag ger uppskattningsvis 15–25 klick/dag att lära av. Justera ner om CPC blir högre än väntat — pausa annonsgrupper med CPC över 10 kr snarare än att låta budgeten ätas upp av ett enda dyrt sökord.
 
+**Max CPC: 3 kr** (manuellt bud, inte Smart Bidding förrän Alternativ B nedan är på plats). Vid 49 kr/brev håller break-even bara om kostnaden per klick ligger lågt — 3 kr ger marginal även vid en försiktig konverteringsgrad. Sätt takbudet på 3 kr per sökord/annonsgrupp i Google Ads, och pausa annonsgrupper som inte får klick alls på den nivån istället för att höja taket.
+
 ## Annonsgrupp 1: Arvskiftesavtal
 **Landningssida:** [arvskifte-mall.html](https://efterplan.se/arvskifte-mall.html)
 


### PR DESCRIPTION
## Ändring

Lägger till en tydlig max-CPC-gräns (3 kr) i `google-ads-underlag-2026-08.md`, baserat på break-even-räkning mot det enda intäktssteget (49 kr-brevet i Stripe).

Bakgrund: vid 49 kr pris kräver break-even ungefär 10 % konvertering vid 5 kr CPC. 3 kr ger marginal vid mer realistisk konvertering och en tydlig regel att sätta i Google Ads-kontot när kampanjen skapas.

Ingen kod ändras — bara marknadsföringsunderlaget.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RDPxX3Bd7XyxxvweaAvj4

---
_Generated by [Claude Code](https://claude.ai/code/session_015RDPxX3Bd7XyxxvweaAvj4)_