### PR TITLE
T237: försäkringsbrevet gratis, övriga brev bakom 49 kr

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,14 +34,23 @@ function clearPremium() {
   applyPremiumState();
 }
 
+// Ett brev är gratis för att visa vad Efterplan skriver — försäkringsbrevet,
+// eftersom det oftast är det som ger mest tillbaka (TGL/livförsäkring som
+// familjen inte visste fanns). Resten låses upp för 49 kr.
+const FREE_DOC_TYPES = ['forsakring'];
+
+function isDocLocked(type) {
+  return PAYWALL_ENABLED && !isPremium() && !FREE_DOC_TYPES.includes(type);
+}
+
 function applyPremiumState() {
   const premium = isPremium();
   document.body.classList.toggle('is-premium', premium);
   const card = document.getElementById('paywall-card');
   if (card) card.classList.toggle('hidden', !PAYWALL_ENABLED || premium);
-  ['doc-btn-skatteverket', 'doc-btn-fullmakt'].forEach(id => {
-    const el = document.getElementById(id);
-    if (el) el.classList.toggle('hidden', PAYWALL_ENABLED && !premium);
+  // Alla brevknappar syns alltid; de betalda får ett lås tills 49 kr betalats.
+  document.querySelectorAll('.doc-type-btn[data-doc], .doc-bulk-cta[data-doc]').forEach(el => {
+    el.classList.toggle('doc-locked', isDocLocked(el.dataset.doc));
   });
   // Re-render the plan so locked-task cards reflect the new state.
   if (typeof renderPlan === 'function' && state && Array.isArray(state.tasks) && state.tasks.length) {
@@ -2515,6 +2524,7 @@ function getDocContext() {
 }
 
 function showDocForm(type) {
+  if (isDocLocked(type)) { showDocPaywall(type); return; }
   document.getElementById('doc-chooser').classList.add('hidden');
   document.querySelectorAll('.doc-form').forEach(f => f.classList.add('hidden'));
 
@@ -2591,6 +2601,24 @@ function backToDocChooser() {
   document.getElementById('doc-result-bulk').classList.add('hidden');
   document.getElementById('doc-chooser').classList.remove('hidden');
   window.scrollTo(0, 0);
+}
+
+// Klick på ett låst brev → visa paywall-kortet i stället för formuläret.
+function showDocPaywall(type) {
+  track('paywall_shown', { doc: type || 'okänd' });
+  if (typeof switchTab === 'function') switchTab('docs');
+  document.querySelectorAll('.doc-form').forEach(f => f.classList.add('hidden'));
+  document.getElementById('doc-result-bulk')?.classList.add('hidden');
+  document.getElementById('doc-chooser').classList.remove('hidden');
+  const card = document.getElementById('paywall-card');
+  if (card) {
+    card.classList.remove('hidden');
+    card.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    card.classList.remove('paywall-card--flash');
+    void card.offsetWidth; // reflow så animationen kan spelas om
+    card.classList.add('paywall-card--flash');
+    card.querySelector('.paywall-cta')?.focus({ preventScroll: true });
+  }
 }
 
 // ─── BULK UPPSÄGNING ──────────────────────────

--- a/arvskifte-guide.html
+++ b/arvskifte-guide.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/arvskifte-guide.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/arvskifte-mall.html
+++ b/arvskifte-mall.html
@@ -19,7 +19,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/arvsskatt.html
+++ b/arvsskatt.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/bankkonto-dodsfall.html
+++ b/bankkonto-dodsfall.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/begravning-utomlands.html
+++ b/begravning-utomlands.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/begravning-utomlands.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/begravningsbyra.html
+++ b/begravningsbyra.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/begravningsbyra.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/bouppteckning-guide.html
+++ b/bouppteckning-guide.html
@@ -19,7 +19,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/bouppteckning-tidslinje.html
+++ b/bouppteckning-tidslinje.html
@@ -12,7 +12,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <link rel="icon" type="image/png" href="/favicon.png" />
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/boutredningsman.html
+++ b/boutredningsman.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/checklista-dodsbo.html
+++ b/checklista-dodsbo.html
@@ -19,7 +19,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/digital-dodsbo.html
+++ b/digital-dodsbo.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/dodsannons.html
+++ b/dodsannons.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/dodsbo-auktion.html
+++ b/dodsbo-auktion.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/dodsbo-auktion.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/dodsbo-bil.html
+++ b/dodsbo-bil.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/dodsbo-bil.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/dodsbo-bostadsratt.html
+++ b/dodsbo-bostadsratt.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/dodsbo-checklista-7-dagar.html
+++ b/dodsbo-checklista-7-dagar.html
@@ -19,7 +19,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/dodsbo-deklaration.html
+++ b/dodsbo-deklaration.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/dodsbo-fastighet.html
+++ b/dodsbo-fastighet.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/dodsbo-skulder.html
+++ b/dodsbo-skulder.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/dodsboanmalan.html
+++ b/dodsboanmalan.html
@@ -18,7 +18,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/dodsfallsintyg.html
+++ b/dodsfallsintyg.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/efterlevandepension.html
+++ b/efterlevandepension.html
@@ -12,7 +12,7 @@
   <meta property="og:url" content="https://efterplan.se/efterlevandepension.html">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/eftersandning-post-dodsbo.html
+++ b/eftersandning-post-dodsbo.html
@@ -18,7 +18,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/forsakring-vid-dodsfall.html
+++ b/forsakring-vid-dodsfall.html
@@ -18,7 +18,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/framtidsfullmakt.html
+++ b/framtidsfullmakt.html
@@ -18,7 +18,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/fullmakt-dodsbo.html
+++ b/fullmakt-dodsbo.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/gratis-checklista-abonnemang.html
+++ b/gratis-checklista-abonnemang.html
@@ -18,7 +18,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/gravsten.html
+++ b/gravsten.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/husdjur-efter-dodsfall.html
+++ b/husdjur-efter-dodsfall.html
@@ -18,7 +18,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'" />
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap" /></noscript>
-  <link rel="stylesheet" href="style.css?v=12" />
+  <link rel="stylesheet" href="style.css?v=13" />
   <link rel="stylesheet" href="style-tokens.css?v=6" />
   <script type="application/ld+json">
   {
@@ -148,7 +148,7 @@
       <button class="btn-primary btn-large" onclick="startOnboarding()">Börja här</button>
       <button class="btn-ghost landing-continue" id="landing-continue" hidden onclick="resumePlan()">Fortsätt din plan →</button>
       <p class="landing-note">Gratis. Det du fyller i finns kvar — även om du stänger sidan.</p>
-      <p class="landing-note landing-note--pricing"><strong>Gratis:</strong> checklista, plan, PDF, bouppteckningsöversikt. <strong>49 kr engångsbetalning:</strong> alla färdigskrivna brev — till banken, försäkringsbolaget, Skatteverket, uppsägning av abonnemang, fullmakt och dödsannons, med mera.</p>
+      <p class="landing-note landing-note--pricing"><strong>Gratis:</strong> hela checklistan, planen, PDF, bouppteckningsöversikt och det färdiga brevet till försäkringsbolaget. <strong>49 kr engångsbetalning:</strong> de övriga breven — till banken, Skatteverket, fullmakt för dödsboet, dödsannons och uppsägning av abonnemang.</p>
     </div>
   </div>
 
@@ -644,7 +644,7 @@
             </div>
           </div>
         </div>
-        <button class="doc-bulk-cta" onclick="showDocForm('bulk')">
+        <button class="doc-bulk-cta" data-doc="bulk" onclick="showDocForm('bulk')">
           <span class="doc-bulk-icon" aria-hidden="true">⚡</span>
           <div class="doc-bulk-text">
             <span class="doc-bulk-title">Avsluta flera tjänster på en gång</span>
@@ -653,32 +653,33 @@
           <span class="doc-bulk-arrow">→</span>
         </button>
         <div class="doc-type-grid">
-          <button class="doc-type-btn" onclick="showDocForm('letter')">
+          <button class="doc-type-btn" data-doc="forsakring" onclick="showDocForm('forsakring')">
+            <span class="doc-badge doc-badge--free">Gratis</span>
+            <span class="doc-icon" aria-hidden="true">🛡</span>
+            <span class="doc-type-title">Till försäkringsbolaget</span>
+            <span class="doc-type-sub">Meddela dödsfallet — och missa inte liv-/tjänstegrupplivförsäkring (TGL) som kan betalas ut</span>
+          </button>
+          <button class="doc-type-btn" data-doc="letter" onclick="showDocForm('letter')">
             <span class="doc-icon" aria-hidden="true">✉</span>
             <span class="doc-type-title">Uppsägningsbrev</span>
             <span class="doc-type-sub">Avsluta ett abonnemang</span>
           </button>
-          <button class="doc-type-btn" onclick="showDocForm('bank')">
+          <button class="doc-type-btn" data-doc="bank" onclick="showDocForm('bank')">
             <span class="doc-icon" aria-hidden="true">🏦</span>
             <span class="doc-type-title">Till banken</span>
             <span class="doc-type-sub">Meddela banken om dödsfallet</span>
           </button>
-          <button class="doc-type-btn" onclick="showDocForm('annons')">
+          <button class="doc-type-btn" data-doc="annons" onclick="showDocForm('annons')">
             <span class="doc-icon" aria-hidden="true">📰</span>
             <span class="doc-type-title">Dödsannons</span>
             <span class="doc-type-sub">Formulera ett minnesvärigt meddelande</span>
           </button>
-          <button class="doc-type-btn" onclick="showDocForm('forsakring')">
-            <span class="doc-icon" aria-hidden="true">🛡</span>
-            <span class="doc-type-title">Till försäkringsbolaget</span>
-            <span class="doc-type-sub">Meddela försäkringsbolaget om dödsfallet</span>
-          </button>
-          <button class="doc-type-btn hidden" id="doc-btn-skatteverket" onclick="showDocForm('skatteverket')">
+          <button class="doc-type-btn" data-doc="skatteverket" id="doc-btn-skatteverket" onclick="showDocForm('skatteverket')">
             <span class="doc-icon" aria-hidden="true">🏛</span>
             <span class="doc-type-title">Skatteverket</span>
             <span class="doc-type-sub">Avsluta F-skatt / enskild firma</span>
           </button>
-          <button class="doc-type-btn hidden" id="doc-btn-fullmakt" onclick="showDocForm('fullmakt')">
+          <button class="doc-type-btn" data-doc="fullmakt" id="doc-btn-fullmakt" onclick="showDocForm('fullmakt')">
             <span class="doc-icon" aria-hidden="true">📋</span>
             <span class="doc-type-title">Fullmakt</span>
             <span class="doc-type-sub">Ge en person rätt att företräda dödsboet</span>
@@ -688,8 +689,8 @@
         <!-- Paywall card — dold tills PAYWALL_ENABLED = true i app.js -->
         <div id="paywall-card" class="paywall-card hidden">
           <div class="paywall-lock" aria-hidden="true">🔒</div>
-          <h2 class="paywall-title">Lås upp alla dokument</h2>
-          <p class="paywall-desc">Lås upp alla brevmallar: till banken, försäkringsbolaget, Skatteverket, uppsägning av abonnemang, fullmakt och dödsannons.</p>
+          <h2 class="paywall-title">Lås upp de övriga breven</h2>
+          <p class="paywall-desc">Försäkringsbrevet är gratis. För 49 kr låser du upp resten — brev till banken, Skatteverket, fullmakt för dödsboet, dödsannons och uppsägning av abonnemang.</p>
           <button class="btn-primary paywall-cta" onclick="handlePaywallCTA()">Lås upp — 49 kr</button>
           <p class="paywall-note">Engångsbetalning. Inga prenumerationer.</p>
         </div>
@@ -1079,7 +1080,7 @@
 </div>
 
 <script src="supabase-client.js?v=3" defer></script>
-<script src="app.js?v=32" defer></script>
+<script src="app.js?v=33" defer></script>
 <script>
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => navigator.serviceWorker.register('./sw.js'));

--- a/laglott.html
+++ b/laglott.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/om.html
+++ b/om.html
@@ -13,7 +13,7 @@
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" type="image/png" href="/favicon.png" />
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/saga-upp-abonnemang-vid-dodsfall.html
+++ b/saga-upp-abonnemang-vid-dodsfall.html
@@ -18,7 +18,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/saga-upp-hyresratt-dodsbo.html
+++ b/saga-upp-hyresratt-dodsbo.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/salja-dodsbo.html
+++ b/salja-dodsbo.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/sambo-arv.html
+++ b/sambo-arv.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/sarkullbarn.html
+++ b/sarkullbarn.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/style.css
+++ b/style.css
@@ -1481,6 +1481,7 @@ body {
 /* ─── DOC TYPE GRID ──────────────────────────── */
 .doc-type-grid { display: flex; flex-direction: column; gap: 10px; }
 .doc-type-btn {
+  position: relative;
   background: var(--bg);
   border: 1.5px solid var(--border);
   border-radius: var(--radius);
@@ -1494,6 +1495,47 @@ body {
   column-gap: 12px;
 }
 .doc-type-btn:hover { border-color: var(--accent); background: var(--accent-light); }
+
+/* Betald/gratis-markör på brevknapparna */
+.doc-badge {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 2px 8px;
+  border-radius: 20px;
+  text-transform: uppercase;
+}
+.doc-badge--free {
+  color: var(--green);
+  background: var(--green-bg);
+  border: 1px solid color-mix(in oklab, var(--green) 22%, transparent);
+}
+.doc-type-btn.doc-locked::after,
+.doc-bulk-cta.doc-locked::after {
+  content: 'Lås upp · 49 kr';
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 2px 8px;
+  border-radius: 20px;
+  color: var(--ink-soft);
+  background: var(--paper-soft);
+  border: 1px solid var(--rule-strong);
+}
+.doc-bulk-cta { position: relative; }
+
+/* Kort blink när ett låst brev klickas */
+@keyframes paywallFlash {
+  0%   { box-shadow: 0 0 0 0 color-mix(in oklab, var(--accent) 45%, transparent); }
+  100% { box-shadow: 0 0 0 14px color-mix(in oklab, var(--accent) 0%, transparent); }
+}
+.paywall-card--flash { animation: paywallFlash 0.7s ease-out 1; }
 .doc-icon {
   grid-row: 1 / 3;
   font-size: 1.3rem;

--- a/testamente-guide.html
+++ b/testamente-guide.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/tomma-dodsbo.html
+++ b/tomma-dodsbo.html
@@ -19,7 +19,7 @@
         href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..600,30..80;1,9..144,400..600,30..80&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"></noscript>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/vad-gora-nar-nagon-dor.html
+++ b/vad-gora-nar-nagon-dor.html
@@ -12,7 +12,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <link rel="icon" type="image/png" href="/favicon.png" />
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {

--- a/vad-kostar-en-begravning.html
+++ b/vad-kostar-en-begravning.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://efterplan.se/og.png">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="style-tokens.css?v=6">
   <script type="application/ld+json">
   {


### PR DESCRIPTION
Löser roadmap **T237** enligt beslut 2026-09-10: **ett brev gratis för att visa värdet, resten bakom 49 kr.**

Gratis-brevet = **försäkringsbrevet**. Det är det som ger mest oväntat tillbaka — många vet inte att den avlidne hade en liv-/tjänstegrupplivförsäkring (TGL via jobb/fack) som kan betalas ut skattefritt, ofta 6+ prisbasbelopp, men bara om någon aktivt begär det.

## Ändringar

**app.js**
- `FREE_DOC_TYPES = ['forsakring']` + `isDocLocked(type)`.
- `showDocForm()` på ett låst brev → `showDocPaywall()` (byter till Dokument-fliken, scrollar till paywall-kortet, kort blink, fokus på CTA). Formuläret öppnas inte.
- `applyPremiumState()`: alla brevknappar syns nu **alltid** — de betalda får klassen `.doc-locked` (CSS-pill "Lås upp · 49 kr"). Skatteverket/fullmakt behåller sin *kontextuella* `.hidden` (visas bara vid företag / flera ansvariga).
- `track('paywall_shown', {doc})` när ett låst brev klickas.

**index.html**
- Försäkringsknappen först, `Gratis`-badge, sub-text nämner TGL.
- `data-doc`-attribut på alla brevknappar. `hidden` borttaget från Skatteverket/fullmakt-knapparna (kontextlogiken i `renderPlan` styr dem i stället).
- Hero-prisraden + paywall-kortets rubrik/text uppdaterade till nya modellen.

**style.css**
- `.doc-badge--free`, `.doc-locked::after`-pill, `paywallFlash`-animation. `?v=13` / `app.js?v=33`.

## Verifierat i browser
Låst brev → paywall (formulär öppnas ej, kort blinkar). Gratis brev → formulär. `setPremium()` → alla lås borta, låst brev öppnar formulär. Inga console-fel.

## Kvar
De fristående gratissidorna (`gratis-checklista-abonnemang.html`, `arvskifte-mall.html`) har egen inline-JS och påverkas inte — fortsatt helt gratis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
